### PR TITLE
docs: Restructure Aztec concepts into topic-based subfolders

### DIFF
--- a/session_01/1_StateAndStorage/StateModel.md
+++ b/session_01/1_StateAndStorage/StateModel.md
@@ -1,0 +1,39 @@
+# 1. State Model: The Two Worlds of Aztec
+
+**Analogy**: Think of Aztec's state like a building with both public announcement boards and private, secure vaults.
+
+Aztec features a **hybrid state model**, meaning it supports both public and private data and operations within its smart contracts.
+
+## Public State
+*   **What it is**: Transparent data, similar to what you find on Ethereum. Everyone can see it.
+*   **How it works**: Managed by smart contract logic. The network's Sequencer executes public state changes, generates proofs of this execution, and publishes the associated data to Ethereum (L1).
+*   **Analogy**: A public notice board in a town square. Anyone can read the notices, and updates are posted for all to see by the town crier (the Sequencer).
+
+## Private State
+*   **What it is**: Encrypted data "owned" by users (or a set of users through shared secrets). Only authorized individuals can decrypt and view it.
+*   **How it works**:
+    *   Stored in an append-only database. This means new data is added, but old data isn't directly changed or deleted in place, as that could leak information.
+    *   "Deleting" private state: Achieved by creating a **nullifier**. This is like marking an old private note as "spent" without revealing its content.
+    *   Modifying private state: You nullify the old state record (e.g., an old note) and create a new one with the updated information. This gives private state an intrinsic **UTXO (Unspent Transaction Output) structure**.
+*   **Analogy**: A personal, magically sealed diary (or a secure vault). Only you have the key. When you update an entry, you write a new one and magically mark the old one as "outdated" (nullified) in a way that doesn't reveal what the old entry was.
+
+## Diagram: Public vs. Private State
+```mermaid
+graph TD
+    A[Aztec Network] --> B{State Model};
+    B --> C[Public State];
+    B --> D[Private State];
+
+    C --> C1[Transparent Data];
+    C --> C2[Managed by Sequencer];
+    C --> C3[Published to Ethereum];
+
+    D --> D1[Encrypted Data];
+    D --> D2[Owned by Users];
+    D --> D3[Append-only (UTXO-like)];
+    D --> D4[Changes via Nullifiers + New Notes];
+```
+
+## Why it Matters for Developers
+*   You can design applications with both transparent public interactions and confidential private user data.
+*   Understanding the append-only nature of private state and the role of nullifiers is crucial for managing private data lifecycles. 

--- a/session_01/1_StateAndStorage/StorageSlots.md
+++ b/session_01/1_StateAndStorage/StorageSlots.md
@@ -1,0 +1,45 @@
+# Storage Slots in Aztec
+
+Understanding how data is organized and accessed at a low level is crucial. While high-level abstractions simplify development, knowing about storage slots helps in comprehending the underlying mechanics of both public and private state.
+
+## Public State Slots
+
+As mentioned in the [State Model](./StateModel.md), Aztec public state behaves similarly to public state on Ethereum from a developer's perspective. However, the underlying storage management differs.
+
+*   **Single Sparse Tree**: Aztec uses one large sparse Merkle tree for all public state.
+*   **Siloing Slots**: To differentiate data belonging to different contracts and different storage variables within those contracts, storage slots are **siloed**. This is done by hashing the `logical_storage_slot` (the slot number you'd think of in your contract code) with the `contract_address`.
+    *   `real_storage_slot = H(contract_address, logical_storage_slot)`
+*   **Mental Model**: Think of a key-value store where the `real_storage_slot` (the siloed slot) is the key, and the value is the data stored. The `real_storage_slot` identifies its position in the global tree, while the `logical_storage_slot` identifies its position within the contract's conceptual storage layout.
+*   **Kernel Circuit Responsibility**: This siloing `(contract_address, logical_storage_slot) -> real_storage_slot` is performed by the Kernel circuits, ensuring data integrity and separation.
+*   **Structs and Arrays**: For complex types like structs and arrays, Aztec logically uses a storage slot computation similar to Ethereum (e.g., a struct with 3 fields would conceptually occupy 3 consecutive logical slots). However, because the `real_storage_slot` is a hash, these actual storage positions in the tree will not be consecutive.
+
+## Private State Slots
+
+Private storage is fundamentally different due to privacy requirements.
+
+*   **Append-Only Note Hash Tree**: Private state is stored as encrypted logs (notes), with their commitments residing in an append-only Merkle tree (the note hash tree). Leaves are never updated or deleted directly; instead, a nullifier is emitted to invalidate a note.
+*   **No Traditional "Slots"**: Directly updating a value at a fixed "storage slot" would leak information (e.g., that *something* at that slot changed), even if the value itself is encrypted. This is why the concept of a fixed, updatable private storage slot doesn't exist in the same way as public state.
+*   **Leaves as Content Commitments**: Leaves in the note hash tree are commitments to the content of the notes (essentially a hash of their content).
+
+### Logical Linking via Storage Slots in Notes
+
+Despite the absence of fixed updatable slots, the *concept* of a storage slot is very useful for application logic (e.g., associating a balance with a user, or a total supply with a token).
+
+*   **Implementation**: To logically link notes that represent a single piece of data (like a user's balance), the `logical_storage_slot` can be included as part of the note data itself.
+    *   A user's balance can then be conceptualized as the sum of all valid (non-nullified) notes that share the same `logical_storage_slot` and belong to that user.
+*   **Note Hash Siloing (Application Level)**: To make this work, the hash of the note (its commitment) incorporates the `logical_storage_slot`:
+    *   `note_hash = H([...packed_note_fields, logical_storage_slot]);`
+    *   This is typically handled within the application circuit (the contract's ZK-SNARK logic).
+*   **`PrivateSet` and `PrivateMutable` in Aztec.nr**: The `Aztec.nr` library provides wrappers like `PrivateSet` and `PrivateMutable`. These abstractions automatically include the `logical_storage_slot` in the commitments they compute, simplifying this for developers.
+*   **Constraining Reads**: When an application circuit reads these notes, it can constrain itself to only consider notes with a specific `logical_storage_slot`.
+
+### Address Siloing (Kernel Level)
+
+To ensure that contracts can only modify their own logical storage and that their notes are unique, a second layer of siloing occurs at the kernel level:
+
+*   **Siloed Note Hash**: The `note_hash` (which already includes the `logical_storage_slot`) is further hashed with the `contract_address` before being inserted into the global note hash tree.
+    *   `siloed_note_hash = H(contract_address, note_hash);`
+*   **Kernel Enforcement**: This address-siloing is enforced by the kernel circuits. This forces inserted note commitments to correctly attribute themselves to the `contract_address`.
+*   **Nullifier Security**: This kernel-level contract siloing is also applied to nullifiers to prevent collisions across different contracts.
+
+For further examples, refer to the developer documentation on storage in Aztec. 

--- a/session_01/2_NotesAndUTXOs/NoteDiscovery.md
+++ b/session_01/2_NotesAndUTXOs/NoteDiscovery.md
@@ -1,0 +1,50 @@
+# Note Discovery in Aztec
+
+Note discovery is the process by which a user identifies and decrypts the encrypted notes that belong to them from the vast amount of encrypted data on the network.
+
+## Existing Solutions & Challenges
+
+1.  **Brute force / Trial-decrypt**:
+    *   **How it works**: The user downloads all possible notes from the network and tries to decrypt each one with their keys. If decryption succeeds, the note belongs to them.
+    *   **Drawbacks**: Becomes exponentially expensive as the network grows. Can introduce reliance on a third-party server for gathering and trial-decrypting notes, adding a point of failure.
+    *   *Status for Aztec*: Not currently the implemented primary method for Aztec.
+
+2.  **Off-chain Communication**:
+    *   **How it works**: The sender of a note directly gives the note content to the recipient through a private, off-chain channel (e.g., secure message).
+    *   **Advantages**: Solves the brute-force issue, can lead to lower transaction costs as less data (like detailed logs for discovery) might need to be posted on-chain.
+    *   **Drawbacks**: Relies on side channels, which might not be desirable for a fully self-sufficient network interaction.
+    *   *Status for Aztec*: Aztec applications **can choose** to use this method if they wish.
+
+## Aztec's Solution: Note Tagging
+
+Aztec introduces an on-chain approach that allows users to efficiently identify which notes are relevant to them by having the sender **tag** the encrypted log in which the note is created. The tag is generated so that (ideally) only the sender and recipient can identify and compute it.
+
+### How Note Tagging Works
+
+1.  **Every Log Has a Tag**:
+    *   In Aztec, each emitted encrypted log (which contains the note data) is an array of fields, e.g., `[tag, encrypted_field1, encrypted_field2, ...] M`.
+    *   The first field is the **tag field**, used to index and identify logs.
+    *   Aztec nodes expose an API (e.g., `getLogsByTags()`) that allows clients (like a user's PXE) to retrieve logs matching specific tags they are interested in.
+
+2.  **Tag Generation**:
+    *   The sender and recipient must agree on a predictable scheme for generating tags.
+    *   The tag is typically derived from a **shared secret** between the sender and recipient, and often an **index** (a shared counter that increments each time the sender creates a note for that specific recipient).
+    *   `tag = H(shared_secret, index)` (Simplified representation)
+
+3.  **Discovering Notes in Aztec Contracts**:
+    *   This note discovery scheme (using tags) is intended to be implemented by **Aztec contracts (Aztec.nr)** rather than being solely a PXE-level function.
+    *   This gives developers flexibility: users can potentially update their discovery methods or use different types of note discovery mechanisms tailored to their application's needs.
+
+### Limitations of Tagging
+
+*   **Unknown Senders**: You generally cannot receive notes from a completely unknown sender if their address is required to compute the shared secret for tag generation. Workarounds might exist (e.g., senders registering in a public list within a contract, and recipients scanning tags derived from those known senders), but they add complexity.
+*   **Index Synchronization**: This is a critical challenge.
+    *   If transactions are reverted or mined out of order, the recipient's expected `index` might get out of sync with the sender's actual `index` used for a tag.
+    *   If a recipient stops searching after receiving a tag with the latest index they expect, they might miss notes that belong to them but were tagged with an earlier (due to reordering) or later (if their expected index was wrong) index.
+    *   Re-using the same index for a reverted and then re-attempted transaction is problematic, as the tag would be the same, potentially linking notes and leaking privacy.
+    *   **Mitigation Strategies**:
+        *   Widening the search window for tags (e.g., checking a range of possible indices around the expected one). This can't be too wide, or it approaches brute-force.
+        *   Implementing restrictions on sending notes (e.g., a user might not be able to send a very large number of notes from the same contract to the same recipient within a very short time frame, to limit index desync issues).
+
+## Further Reading
+*   The specifics of how partial notes (notes whose content isn't fully known yet but are detected via tags) are discovered and handled by the PXE and contracts is an area of ongoing development and refinement in the Aztec ecosystem. 

--- a/session_01/2_NotesAndUTXOs/Notes.md
+++ b/session_01/2_NotesAndUTXOs/Notes.md
@@ -1,0 +1,75 @@
+# 2. Notes (UTXOs): Aztec's Private Money
+
+**Analogy**: Notes are like encrypted digital cash or individual, sealed envelopes containing value, rather than a public bank account balance.
+
+Private state in Aztec is managed using **Notes**, which are essentially Unspent Transaction Outputs (UTXOs).
+
+## What are Notes?
+*   Encrypted pieces of data that can only be decrypted by their owner(s).
+*   Each note specifies its owner. Unlike account-based models (e.g., Ethereum accounts), there's no direct link between a user's "account" and the data's location in a tree.
+*   Instead of storing entire notes directly in a public data tree, **note commitments** (hashes of the notes) are stored in a Merkle tree called the **note hash tree**.
+*   When users want to use a note (e.g., spend it), they provide a proof that they have the pre-image information for the note commitment without revealing the note itself.
+
+## How Notes Work
+1.  **Creation**: A new note is created, encrypted for its owner. Its commitment is added to the note hash tree.
+2.  **Spending/Updating**:
+    *   The original note's commitment is **nullified** (invalidated) by creating a nullifier derived from the note data.
+    *   New notes may be created (e.g., a change note for the original owner, and a payment note for a recipient).
+    *   This decouples the actions of creating, updating, and "deleting" private state.
+
+**Example - Spending a Note**: Imagine you have a private $5 note. You want to pay someone $3.50.
+*   You nullify your $5 note.
+*   You create a new $1.50 note for yourself (change).
+*   You create a new $3.50 note for the recipient.
+*   Crucially, an outside observer cannot link your original $5 note to the $3.50 payment or the $1.50 change. Only you and the recipient are aware of the $3.50 transaction details.
+
+## Sending Notes
+There are a few ways to get a note to its intended recipient:
+1.  **On-chain (Encrypted Logs)**: The most common method. Encrypted note data is posted on-chain as part of a transaction. The recipient can then discover and decrypt it.
+2.  **Off-chain (Out of Band)**: If you know the recipient directly, you can share the note data with them privately (e.g., over a secure chat).
+3.  **Self-created Notes**: If you create a note for yourself (e.g., a change note), you don't need to broadcast it. You keep it in your Private Execution Environment (PXE).
+
+## Abstraction with Aztec.nr
+*   Users typically don't interact with individual notes directly.
+*   The `Aztec.nr` smart contract library abstracts this complexity. Developers can define **custom note types** and how they are handled.
+*   Users see their aggregated asset balances (e.g., "You have 10 PrivateDAI"), similar to an Ethereum account experience.
+*   `Aztec.nr` also helps with **note discovery** (finding all notes encrypted for a user's account).
+
+## Diagram: Note Lifecycle
+```mermaid
+graph TD
+    subgraph User A's PXE (Private)
+        N1_5["Note: $5 (Owned by A)"]
+    end
+
+    subgraph Aztec Network (Public Trees)
+        NC1_5["Commitment(Note $5)"]
+        NullSet["Nullifier Set"]
+    end
+
+    subgraph User B's PXE (Private)
+        N2_35["Note: $3.5 (Owned by B)"]
+    end
+    
+    subgraph User A's PXE (Private)
+        N3_15["Note: $1.5 (Owned by A)"]
+    end
+
+    N1_5 --"1. User A decides to spend $3.50"--> P1{Process Transaction};
+    P1 --"2. Nullify $5 Note"--> AddNullifier;
+    AddNullifier["Add Nullifier(Note $5)"] --> NullSet;
+    NC1_5 -.-> AddNullifier;
+    
+    P1 --"3. Create new $3.50 note for B"--> N2_35;
+    P1 --"4. Create new $1.50 note for A (change)"--> N3_15;
+
+    N2_35 --> NC2_35["Commitment(Note $3.5)"];
+    N3_15 --> NC3_15["Commitment(Note $1.5)"];
+
+    NC2_35 & NC3_15 --> NoteHashTable[Note Hash Tree]
+```
+
+## Why it Matters for Developers
+*   Notes are the fundamental building blocks of private assets and state in Aztec.
+*   Understanding how to define and manage custom note types in `Aztec.nr` is key to building applications.
+*   The concept of nullifiers is central to preventing double-spends and managing private state changes. 

--- a/session_01/2_NotesAndUTXOs/NullifierTrees.md
+++ b/session_01/2_NotesAndUTXOs/NullifierTrees.md
@@ -1,0 +1,186 @@
+# Nullifier Trees: Efficiently Preventing Double Spends
+
+In systems with private state, like Aztec, preventing an asset (a "note" or UTXO) from being spent more than once is critical. This is achieved using **nullifiers**. When a note is spent, a unique nullifier corresponding to that note is published. The system must then check that this nullifier hasn't been seen before.
+
+This page explores how Aztec aims to manage these nullifiers efficiently using a structure based on Indexed Merkle Trees.
+
+## Primer on Nullifier Trees
+
+*   **Why needed?**: In a UTXO model, state is stored in encrypted notes. To maintain privacy, you don't "update" a note; you "destroy" (nullify) the old one and create new ones.
+*   **Append-Only Note Trees**: The tree storing the notes themselves is append-only.
+*   **Nullifier Tree's Role**: A separate data structure, the nullifier tree, is used to record which notes have been spent. When attempting to spend a note, a user must prove that its corresponding nullifier *does not already exist* in the nullifier tree.
+
+### Traditional Sparse Merkle Trees for Nullifiers
+
+*   **Concept**: A sparse Merkle tree could theoretically store nullifiers. Each possible nullifier value maps to a leaf index. If `tree_values[nullifier_value] == 0`, it's not spent; if `1`, it is.
+    ```mermaid
+    graph TD
+        R((Root))
+        R --> H1
+        R --> H2
+        H1 --> L1["Leaf 0 (value)"]
+        H1 --> L2["Leaf 1 (0)"]
+        H2 --> L3["Leaf ... (0)"]
+        H2 --> L4["Leaf 2^n-1 (value)"]
+        subgraph Sparse Merkle Tree Example
+            direction LR
+            L1
+            L2
+            L3
+            L4
+        end
+    ```
+*   **Problem**: For a large nullifier space (e.g., 254-bit field elements), the tree would be extremely deep (254 levels). Each non-membership proof and subsequent insertion requires hashing up the tree (e.g., 254 hashes for non-membership, 254 for insertion). This is too computationally expensive for rollup circuits, where these checks occur.
+
+## Indexed Merkle Trees: A More Efficient Approach
+
+Introduced in [this paper (page 6)](https://eprint.iacr.org/2019/1255.pdf), Indexed Merkle Trees offer efficient non-membership proofs by changing how data is stored and linked.
+
+*   **Structure**: Instead of placing leaves at `index == value`, leaves are appended, and each node stores not just its value `v` but also pointers (`next_index`, `next_value`) to the leaf with the *next highest value* in the tree. The tree essentially maintains a sorted linked list of nullifiers.
+    *   Leaf structure: `{ value: Field, next_index: Field, next_value: Field }`
+*   **Assumption**: If a leaf has `value = v1` and `next_value = v2`, there are no other leaves in the tree with a value strictly between `v1` and `v2`.
+*   **Benefit**: The tree doesn't need to be as deep as a sparse Merkle tree (e.g., depth 32 might suffice), significantly reducing hash operations (e.g., from ~250 to ~30 per operation).
+
+### Visualizing Insertions (Conceptual Linked List)
+
+Let `(v, ni, nv)` denote `(value, next_index, next_value)`. `idx_X` is the tree index of the leaf for value X.
+We assume a `0` node is pre-populated, pointing to the largest possible value or `0` if the tree is empty/`value` is the current max.
+
+1.  **Initial State (conceptual, tree has a 0-node placeholder):**
+    ```mermaid
+    graph LR
+        N0["Leaf at idx_0: (0, 0, 0)"] -- next_value points to 0 (empty or end) --> N0;
+    ```
+
+2.  **Add New Value `v=30` (inserted at `new_idx_30`):**
+    *   Low nullifier is Leaf 0.
+    *   Update Leaf 0: `(0, new_idx_30, 30)`
+    *   New Leaf 30: `(30, 0, 0)` (points to end)
+    ```mermaid
+    graph LR
+        N0["Leaf at idx_0: (0, new_idx_30, 30)"] --> N30["Leaf at new_idx_30: (30, 0, 0)"];
+        N30 -- next_value points to 0 --> N0;
+    ```
+
+3.  **Add New Value `v=10` (inserted at `new_idx_10`):**
+    *   Low nullifier is Leaf 0.
+    *   Update Leaf 0: `(0, new_idx_10, 10)`
+    *   New Leaf 10: `(10, new_idx_30, 30)` (original `next_value` of Leaf 0)
+    ```mermaid
+    graph LR
+        N0["Leaf at idx_0: (0, new_idx_10, 10)"] --> N10["Leaf at new_idx_10: (10, new_idx_30, 30)"];
+        N10 --> N30["Leaf at new_idx_30: (30, 0, 0)"];
+        N30 -- next_value points to 0 --> N0;
+    ```
+
+4.  **Add New Value `v=20` (inserted at `new_idx_20`):**
+    *   Low nullifier is Leaf 10.
+    *   Update Leaf 10: `(10, new_idx_20, 20)`
+    *   New Leaf 20: `(20, new_idx_30, 30)` (original `next_value` of Leaf 10)
+    ```mermaid
+    graph LR
+        N0["Leaf at idx_0: (0, new_idx_10, 10)"] --> N10["Leaf at new_idx_10: (10, new_idx_20, 20)"];
+        N10 --> N20["Leaf at new_idx_20: (20, new_idx_30, 30)"];
+        N20 --> N30["Leaf at new_idx_30: (30, 0, 0)"];
+        N30 -- next_value points to 0 --> N0;
+    ```
+
+(The actual tree structure is a Merkle tree; the above shows the logical linked list via pointers.)
+
+### Insertion Protocol (Simplified)
+
+1.  **Find Low Nullifier**: Find an existing leaf (`low_nullifier_leaf`) in the tree such that `low_nullifier_leaf.value < new_nullifier` and `low_nullifier_leaf.next_value > new_nullifier` (or `low_nullifier_leaf.next_value == 0` if `new_nullifier` is the largest so far).
+2.  **Membership Check**: Prove `low_nullifier_leaf` exists in the tree (Merkle proof).
+3.  **Range Check**: Verify that `new_nullifier` indeed falls between `low_nullifier_leaf.value` and `low_nullifier_leaf.next_value`.
+4.  **Update Low Nullifier's Pointers**: Modify `low_nullifier_leaf` so its `next_index` points to the index where `new_nullifier` will be inserted, and its `next_value` becomes `new_nullifier`.
+5.  **Insert Updated Low Nullifier**: Insert this modified `low_nullifier_leaf` back into the Merkle tree (this yields a new Merkle root).
+6.  **Create New Leaf**: Prepare the leaf for `new_nullifier`. Its `value` is `new_nullifier`. Its `next_index` and `next_value` are taken from the *original* `low_nullifier_leaf`'s `next_index` and `next_value` (before it was updated in step 4).
+7.  **Insert New Leaf**: Insert this new leaf for `new_nullifier` into an empty slot in the Merkle tree (yields the final new Merkle root).
+
+This involves roughly 3 Merkle path hashes (1 read, 2 updates/insertions of depth ~32) plus some equality and range checks, far fewer than the 2 * 254 hashes of a deep sparse tree.
+
+### Non-Membership Proof
+
+To prove `value_x` does *not* exist:
+1.  Reveal the `low_nullifier_leaf` such that `low_nullifier_leaf.value < value_x` and `low_nullifier_leaf.next_value > value_x` (or `next_value == 0` if `value_x` would be largest).
+2.  Prove `low_nullifier_leaf` is in the tree (Merkle proof, `n` hashes where `n` is tree depth).
+3.  Perform range checks to show `value_x` falls strictly between `low_nullifier_leaf.value` and `low_nullifier_leaf.next_value`.
+
+### Batch Insertions
+
+Since nullifiers are often inserted in batches within a rollup, further optimizations are possible.
+
+*   **Append-Only Nature**: New nullifiers are appended to the tree structure.
+*   **Subtree Insertion**: Instead of inserting nodes one by one, an entire subtree of new nullifiers can be calculated and then inserted into the main tree.
+    1.  Prove the target location in the main tree (where the new subtree will attach) is currently empty.
+    2.  Construct the new subtree with new nullifiers and their updated pointers locally.
+    3.  Use the sibling path from step 1 to calculate the new root of the main tree after attaching the new subtree root.
+*   **Complexity with Pointers**: When batching, a `low_nullifier_leaf` for a new nullifier might itself be *within the batch being inserted* (a "pending" insertion). The circuit logic must handle these cases by checking pending values before looking at the main tree state.
+
+**Performance Gains**: Batching significantly reduces per-nullifier hashing costs compared to individual insertions.
+
+### Circuit Logic for Batch/Pending Insertions (Conceptual Pseudocode)
+
+```
+// Inputs: new_nullifiers[], low_leaf_preimages[], low_leaf_witnesses[], current_root, next_insertion_idx, subtree_path
+
+empty_subtree_hash = CONSTANT_EMPTY_SUBTREE_HASH;
+pending_insertion_subtree = [];
+insertion_idx = inputs.next_insertion_index;
+root = inputs.current_nullifier_tree_root;
+
+// 1. Check if the slot for the new subtree is empty in the current tree
+assert(membership_check(root, empty_subtree_hash, insertion_idx >> subtree_depth, inputs.subtree_insertion_sibling_path));
+
+for (i in 0..len(new_nullifiers)) {
+    current_new_nullifier = inputs.new_nullifiers[i];
+    low_leaf = inputs.low_nullifier_leaf_preimages[i];
+    low_witness = inputs.low_nullifier_membership_witnesses[i];
+    found_low_in_pending = false;
+
+    // 2. Is the low_nullifier_leaf for current_new_nullifier in the pending batch?
+    if (low_witness is marked_as_pending_lookup) { // e.g., witness is null or index is special
+        for (j in 0..i) { // Search already processed items in this batch
+            pending_leaf = pending_insertion_subtree[j];
+            if (pending_leaf.value < current_new_nullifier && 
+                (pending_leaf.next_value > current_new_nullifier || pending_leaf.next_value == 0)) {
+                // Found low_nullifier in pending batch. Update its pointers.
+                // Original next pointers of pending_leaf go to current_new_nullifier's leaf.
+                // pending_leaf now points to current_new_nullifier.
+                // ... (update logic for pending_leaf and setup for current_new_nullifier_leaf) ...
+                pending_insertion_subtree.push(new_leaf_for_current_nullifier);
+                found_low_in_pending = true;
+                break;
+            }
+        }
+        assert(found_low_in_pending); // Must be found if marked as pending
+    } else {
+        // 3. Low_nullifier is in the main tree. Standard verification.
+        assert(perform_membership_check(root, hash(low_leaf), low_witness)); // Check low_leaf is in current tree root
+        // Range checks for current_new_nullifier against low_leaf
+        assert(current_new_nullifier > low_leaf.value);
+        assert(current_new_nullifier < low_leaf.next_value || low_leaf.next_value == 0);
+
+        // Prepare new_leaf_for_current_nullifier (value = current_new_nullifier, next pointers from low_leaf.next)
+        // Update low_leaf's next pointers to point to current_new_nullifier (at future insertion_idx)
+        
+        // Update the main tree root by re-inserting the modified low_leaf
+        root = update_leaf_in_tree(root, low_leaf_modified, low_witness);
+        pending_insertion_subtree.push(new_leaf_for_current_nullifier);
+    }
+    insertion_idx++; // For the next nullifier in the batch
+}
+
+// 4. Insert the entire pending_insertion_subtree into the main tree structure
+root = insert_subtree_into_main_tree(root, inputs.next_insertion_index >> subtree_depth, pending_insertion_subtree, inputs.subtree_insertion_sibling_path);
+
+// return final root
+```
+
+### Drawbacks
+
+*   **Node Computation/Storage**: While in-circuit costs are lower, the node (off-chain component) needs to do more work to find the correct `low_nullifier_leaf` for any new nullifier. This might involve searching or maintaining a sorted data structure of existing nullifiers, increasing node storage/CPU requirements.
+
+### Conclusion
+
+Indexed Merkle Trees, especially with batching, offer significant performance improvements for nullifier checks within ZK circuits compared to traditional sparse Merkle trees. This is crucial for the efficiency of rollup systems like Aztec that rely on private state and nullification. 

--- a/session_01/3_ExecutionEnvironment/ACIRSimulator.md
+++ b/session_01/3_ExecutionEnvironment/ACIRSimulator.md
@@ -1,0 +1,45 @@
+# ACIR Simulator
+
+The ACIR (Abstract Circuit Intermediate Representation) Simulator is a key component responsible for the simulation of Aztec smart contract function executions. Its primary purpose is to aid in the correct execution of Aztec transactions by pre-determining their outcomes and collecting necessary data.
+
+## Core Functionality
+
+Simulating a function with the ACIR Simulator involves:
+
+*   **Generating a Partial Witness**: This is the set of specific inputs (including private ones) that satisfy the function's logic (the circuit).
+*   **Generating Public Inputs**: These are the inputs to the circuit that will be publicly visible.
+*   **Collecting Data**: Gathering all essential data outputs and side effects from the simulated execution. This includes:
+    *   New notes created.
+    *   Nullifiers for spent notes.
+    *   Public state changes.
+    *   Any other data necessary for components further down the transaction processing pipeline (e.g., for proof generation or kernel circuit inputs).
+
+## Simulating Different Function Types
+
+The ACIR Simulator can handle all three types of Aztec contract functions:
+
+### 1. Private Functions (`#[private]`)
+*   **Execution Environment**: Simulated and subsequently proven client-side (e.g., within the user's [PXE](./PXE.md)).
+*   **Verification**: The generated proof is verified client-side by the private kernel circuit.
+*   **Oracle Assistance**: Private function simulations are run with the assistance of a **DB oracle**. This oracle is an interface (typically implemented by the PXE) that provides any private data requested by the function during its execution (e.g., specific notes to spend, user keys, authwits).
+    *   *Further reading on oracle functions can be found in the smart contract section of the official Aztec documentation.*
+*   **Composability**:
+    *   Private functions can call other private functions (synchronously within the simulation).
+    *   Private functions can *request* to call a public function. This public function execution will be performed asynchronously by the sequencer in the actual transaction. Therefore, private functions do not have direct access to the return values of public functions they enqueue within the same transaction.
+
+### 2. Public Functions (`#[public]`)
+*   **Execution Environment**: Simulated and proven on the sequencer side.
+*   **Verification**: Verified by the public kernel circuit (also on the sequencer side).
+*   **Oracle Assistance**: Public function simulations are run with the assistance of an oracle that provides any values read from the public state tree.
+*   **Composability**:
+    *   Public functions can call other public functions. This composability can happen atomically within the public execution phase.
+    *   Public functions *can* call private functions, but this also happens asynchronously. The private function call must be processed in a future block, as it requires client-side proving.
+
+### 3. Utility Functions (`#[utility]`)
+*   **Purpose**: Used to extract useful data for users or client applications, such as querying a user's private balance. They are not part of an on-chain transaction's execution flow.
+*   **Execution Environment**: Simulated client-side (e.g., within the PXE).
+*   **No Proofs**: Utility functions are **not proven**.
+*   **Oracle Assistance**: They are run with the assistance of an **oracle resolver** (typically part of the PXE) that provides any private or public data requested by the function.
+*   **Composability (Current Limitations)**:
+    *   At present, utility functions generally cannot call other functions (private, public, or other utility functions).
+    *   Allowing utility functions to call other utility functions is on the Aztec roadmap. 

--- a/session_01/3_ExecutionEnvironment/PXE.md
+++ b/session_01/3_ExecutionEnvironment/PXE.md
@@ -1,0 +1,104 @@
+# Private Execution Environment (PXE)
+
+The Private Execution Environment (PXE, pronounced "pixie") is a crucial client-side library in Aztec, enabling the execution of private operations. It's typically a TypeScript library runnable in Node.js, directly within wallet software, or even in a browser.
+
+The PXE's primary role is to generate proofs for private function executions. These proofs, along with any requests for public function execution, are then sent to the sequencer. A key design principle is that **private inputs never leave the client-side PXE**.
+
+## Responsibilities of the PXE
+
+*   **Secret Storage**: Securely stores secrets like encryption keys, private notes, and tagging secrets (used for [note discovery](./../NotesAndUTXOs/NoteDiscovery.md)). It exposes a safe interface for accessing them.
+*   **Private Execution & Proof Generation**: Orchestrates the execution of private functions (which are circuits) and the generation of their corresponding ZK-SNARK proofs. This includes implementing oracles needed by the contract circuits during transaction execution.
+*   **State Syncing**: Syncs the user's relevant network state (both public and private) by obtaining data from an Aztec node.
+*   **Multi-Account Management**: Can handle data and secrets for multiple user accounts while providing necessary isolation and siloed permissions between them.
+
+## System Architecture
+
+The PXE sits at the heart of client-side operations, interacting with various components:
+
+```mermaid
+graph TD
+    User ==> Wallet;
+    User ==> DApp;
+
+    subgraph ClientSide [Client-Side Components]
+        Wallet -- Prompts / Calls (auth needed) --> PXE;
+        DApp -- Calls (auth needed) --> PXE;
+        PXE -- Manages / Executes --> ACIR_Circuits[ACIR Circuits];
+        PXE -- Provides Data via Oracles --> ACIR_Circuits;
+        PXE_DB[(PXE Database: Notes, AuthWits, Keys)] --> PXE;
+    end
+
+    PXE -- Sends Tx (Proofs + Public Requests) --> AztecNode[Aztec Node];
+    PXE -- Syncs State / Queries --> AztecNode;
+    
+    DApp -- Interacts with --> Wallet;
+```
+
+*   **User**: Interacts with DApps and Wallets.
+*   **DApp/Wallet**: Initiate actions, request data, and prompt the user. They communicate with the PXE for any operations involving private state or private execution.
+*   **PXE**: The core engine for private operations.
+*   **ACIR Circuits**: The smart contract logic for private functions, executed/proven within the PXE.
+*   **Aztec Node**: The user's gateway to the Aztec network for broadcasting transactions and fetching state.
+
+## Components of the PXE
+
+### 1. Transaction Simulator
+*   **Initiation**: An application (DApp or Wallet) prompts the user's PXE to execute a transaction (e.g., execute function X with arguments Y from account Z).
+*   **Gas Estimation**: The application or wallet might handle gas estimation prior to simulation.
+*   **ACIR Simulator**: This component handles the actual execution simulation of smart contract functions (private, public, and utility). It generates the necessary data (partial witness, public inputs) and collects side effects (new notes, nullifiers, state changes). More details can be found in the [ACIR Simulator](./ACIRSimulator.md) section.
+*   **Authwits for Simulation**: Until "simulated simulations" (a feature to predict authwit needs, tracked as #9133) are fully implemented, authentication witnesses (authwits) are generally required *before* simulation if the functions being simulated need them.
+
+### 2. Proof Generation
+*   **Process**: After a successful simulation, the wallet calls `proveTx` on the PXE.
+*   **Inputs to `proveTx`**: All data generated during simulation (e.g., execution trace, new notes, nullifiers) and any required authentication witnesses (which allow other contracts to act on behalf of the user's account contract).
+*   **Output**: A proven transaction (containing ZK proofs for private functions).
+*   **Broadcast**: The wallet then sends this proven transaction to the network (via an Aztec Node) and typically returns the transaction hash to the application for tracking.
+
+### 3. Database
+
+The PXE maintains a local database to store transactional data and user-specific private information.
+
+*   **Notes**: Encrypted data representing users' private state. While the encrypted blobs might be on-chain, the PXE stores the decrypted versions for accounts it manages. Contracts often parse on-chain data to find relevant notes, which are then stored in the PXE by the wallet.
+*   **Authentication Witnesses (AuthWits)**: Data (often signatures or other proofs) used to approve other entities (contracts, users) to execute transactions on the current user's behalf. The PXE provides these to transactions on-demand during simulation via oracle calls. See [Authentication Witness (Authwit)](./../AccountsAndAuth/AuthWit.md).
+*   **Capsules**: External data or data injected into the system via oracles during contract execution.
+*   **Address Book**: A list of expected Aztec addresses that the PXE may encrypt notes for, or from whom it might receive encrypted notes. This helps the PXE optimize the note discovery process by reducing the search space.
+
+*Note on Note Discovery*: The PXE itself is *not* directly in charge of the core note discovery logic (i.e., finding all notes owned by the user across the entire chain). This discovery process, often using tagging mechanisms, is typically handled by logic within Aztec contracts (Aztec.nr). The PXE then stores the discovered and decrypted notes. Learn more about [Note Discovery](./../NotesAndUTXOs/NoteDiscovery.md).
+
+### 4. Authorization & Scopes
+
+The PXE manages fine-grained access rights for DApps and other callers. Permissions can be scoped by:
+*   **Action**: What can be done (e.g., query notes, simulate a call).
+*   **Domain**: The origin of the request (e.g., `uniswap.com`).
+*   **Contract**: The specific contract address the action pertains to.
+*   **Account**: The specific user account within the PXE the action is for.
+
+**Example**: `uniswap.com` (domain) can `query private notes` (action) on `five specific token contracts` (contracts) for `two of my accounts` (accounts) registered in the PXE.
+
+**Available Actions (Examples)**:
+*   Checking if an account exists in the PXE.
+*   Running queries, simulations, accessing logs, registering contracts for a given contract address.
+*   Manually adding notes to the PXE's database.
+
+**Scope Definition**: When a DApp interacts with the PXE, it can specify scopes:
+*   `scopes: []` (empty array): No information can be accessed.
+*   `scopes: undefined` (or not provided): Defaults to all available/permissible scopes for that DApp/domain.
+
+### 5. Contract Management
+*   Applications can request the user's PXE to add the bytecode (artifact) of contracts required for interaction.
+*   The PXE will check if these contracts have already been registered.
+*   **Privacy Note**: There are typically no direct getter functions to check if a specific contract has been registered by a DApp, as this could leak information about a user's interaction history (e.g., a malicious DApp could try to fingerprint users by checking for the presence of known DApp contracts in their PXE).
+
+### 6. Keystore
+*   A secure storage component within the PXE for managing the user's private and public keys (e.g., encryption keys, nullifier keys, signing keys if used by the account contract).
+
+### 7. Oracles
+*   Oracles in Aztec are mechanisms for providing client-side data to smart contract functions during their (private) execution. The PXE implements these oracle interfaces.
+*   When a private function in an Aztec.nr contract makes an oracle call (e.g., to get a specific note to spend, or to get an authwit), the PXE intercepts this call and provides the requested data from its database or generates it as needed.
+*   You can read more about oracles in the smart contracts section of the main Aztec documentation.
+
+## For Developers
+
+To learn how to develop on top of the PXE, refer to these guides in the official Aztec documentation:
+*   Running more than one PXE on your local machine.
+*   Using in-built oracles, including oracles for arbitrary data. 

--- a/session_01/3_ExecutionEnvironment/Wallets.md
+++ b/session_01/3_ExecutionEnvironment/Wallets.md
@@ -1,0 +1,92 @@
+# Wallets: Your Gateway to Aztec
+
+**Analogy**: An Aztec wallet is like a highly advanced personal assistant and a secure briefcase combined. It not only holds your keys and assets but also performs complex computations (proofs) on your behalf.
+
+Wallets in Aztec are user-facing applications that manage accounts and interact with dapps. They have standard responsibilities and some unique to Aztec's private nature.
+
+## Standard Wallet Responsibilities
+*   Managing user accounts (creating, browsing).
+*   Monitoring balances.
+*   Storing seed phrases and private keys (or interfacing with hardware wallets/keystores).
+*   Providing an interface for dapps to request actions (e.g., view account state, send transactions).
+
+## Aztec-Specific Wallet Responsibilities
+*   **Track Private State**: Maintain a local, encrypted database of all private notes belonging to the user's accounts. This involves scanning blocks and trying to decrypt notes.
+*   **Produce Local Proofs**: Generate zero-knowledge proofs for the execution of private functions *locally on the user's device*. This is a major difference from chains where all execution happens on network nodes.
+
+## Account Setup
+*   Users deploy an **account contract** to represent their account on-chain. This contract dictates how their transactions are authenticated and executed.
+*   Wallets support specific account contract implementations.
+*   **Deterministic Addresses**: Wallets can generate a complete Aztec address for a user *before* their account contract is deployed. This allows users to receive funds even if they haven't yet paid gas to deploy their contract.
+
+## Transaction Lifecycle (Simplified)
+1.  **Dapp Request**: A dapp requests the wallet to perform an action (e.g., "transfer 5 PrivateETH").
+2.  **Execution Request**: The wallet creates an execution request, including instructions for the user's account contract.
+3.  **Local Simulation & Proving (Private Part)**:
+    *   The wallet simulates the private functions involved in the transaction.
+    *   It then generates ZK proofs of correct execution for these private functions. This happens locally.
+    *   This step also determines new notes to be created and old notes to be nullified.
+4.  **Send to Network**: The wallet sends the transaction (which includes the proofs and public data like nullifiers and new note commitments) to an Aztec Node.
+5.  **Sequencing & Settlement**: The node relays it to a Sequencer, who validates proofs, executes any public parts, and includes it in a block that eventually settles on L1.
+
+**Key Point**: The private execution trace (what happens inside private functions) is deterministic because it depends only on the input notes, which are immutable. However, the transaction might be dropped if an input note was already nullified by another transaction. Public function execution depends on the public chain state at the time of inclusion.
+
+## Authorizing Actions
+Account contracts can authorize other contracts or users to perform actions.
+*   **Private Functions**: Use **auth witnesses**. These are typically signatures over an action's identifier. The wallet generates these via a `createAuthWit` call when requested by an application. (See [Authentication Witness (Authwit)](./../AccountsAndAuth/AuthWit.md) for details).
+*   **Public Functions**: Authorizations are often pre-stored in the account contract's public storage.
+
+## Key Management
+*   **Privacy Keys**: Mandated by the protocol, used for encryption and nullification. Currently, these need to be available in the wallet software itself.
+*   **Authentication Keys**: Dependent on the specific account contract implementation (e.g., ECDSA keys, WebAuthn credentials). These can often be rotated or recovered if the account contract supports it.
+(See [Keys](./../Keys/Keys.md) for more details).
+
+## Recipient Encryption Keys
+Wallets manage a registry of public encryption keys for known recipients to facilitate sending encrypted notes.
+
+## Private State Synchronization
+*   Wallets typically **brute-force decrypt** encrypted data blobs in new blocks using the user's decryption keys. (More advanced methods like [Note Discovery](./../NotesAndUTXOs/NoteDiscovery.md) with tagging are also employed).
+*   If a blob decrypts successfully, the note is added to the user's local private state database.
+*   This means wallets can reconstruct a user's entire private state from their encryption keys if local data is lost, as long as the encrypted data is on L1.
+
+## Wallet Architecture: Under the Hood
+
+**Core Idea**: An Aztec wallet is essentially an instance of a **Private Execution Environment (PXE)** that also handles user keys and private state. (See [Private Execution Environment (PXE)](./PXE.md) for details).
+
+### Overview
+*   **PXE (Private Execution Environment)**: This is the engine that runs locally.
+*   **Local Database**: The PXE requires a local database for storing private notes and other relevant data.
+*   **Syncing**: Continuously syncs new blocks to trial-decrypt notes.
+*   **Account Contract Implementations**: A wallet must be able to handle one or more specific account contract implementations.
+
+### Key Interfaces (from `aztec.js`)
+1.  **`AccountInterface`**:
+    *   JavaScript/TypeScript counterpart to an on-chain account contract.
+    *   Defines how to create execution requests and generate auth witnesses for a specific account contract.
+2.  **`PXEInterface`**:
+    *   The interface dapps use to interact with the wallet.
+    *   Provides functions for account/contract registration, transaction simulation/proving/sending, querying state, etc.
+
+### Diagram: Wallet Architecture High-Level
+```mermaid
+graph TD
+    User --> DAppUI["DApp UI (Web/Mobile)"];
+    
+    subgraph Wallet Software
+        DAppUI --> PXEInterface["PXE Interface (e.g., Aztec.js)"];
+        PXEInterface <--> PXECore["PXE Core Engine (includes PXE functionality)"];
+        PXECore --> AccountHandlers["Account Contract Handlers (AccountInterface implementations)"];
+        PXECore <--> KeyStore["Key Store (Privacy & Auth Keys)"];
+        PXECore <--> PrivateStateDB["Private State DB (Notes)"];
+    end
+
+    PXECore --> AztecNode["Aztec Node (P2P Network)"];
+    AztecNode <--> SequencerProver["Sequencer/Prover Network"];
+    SequencerProver --> L1Rollup["L1 Rollup Contract (Ethereum)"];
+```
+
+## Why it Matters for Developers
+*   Dapps interact with wallets, not directly with the low-level protocol for many operations.
+*   Understanding the wallet's role in local proof generation and private state management is crucial for dapp UX.
+*   The `createAuthWit` mechanism is important for dapps that need to perform actions on behalf of users.
+*   Wallets choose which account contract implementations they support, influencing user options for authentication and recovery. 

--- a/session_01/4_AccountsAndAuth/Accounts.md
+++ b/session_01/4_AccountsAndAuth/Accounts.md
@@ -1,0 +1,58 @@
+# Accounts: Smart Accounts for Everyone
+
+**Core Idea**: Aztec has **native Account Abstraction (AA)**. This means *every* account on Aztec is a smart contract, not just a private key. There are no Externally Owned Accounts (EOAs) like in Ethereum.
+
+## What is Account Abstraction?
+AA allows a user's on-chain identity to be represented by a smart contract with custom logic, rather than being rigidly tied to a private/public key pair. This enables features like:
+*   Account recovery (social recovery, etc.).
+*   Gas sponsorship (dapps paying fees for users).
+*   Support for various authentication methods (e.g., Schnorr signatures, BLS signatures, WebAuthn/passkeys, multi-factor authentication).
+*   Custom transaction validation logic.
+
+## Aztec's Native AA Advantages
+*   **No Limits on Verification Logic Complexity (for on-chain cost)**: Because the most complex parts of account verification (like signature checks or multi-sig logic) happen in private functions and are proven client-side, their complexity doesn't directly translate to higher gas fees on L2. The sequencer only verifies a lightweight proof.
+    *   **Example**: A multisig contract needing 10 out of 20 signatures, or an oracle contract verifying data from many providers, can have this complex logic proven efficiently by the user's [PXE](./../ExecutionEnvironment/PXE.md).
+*   **Flexibility**: Developers can define how an account authenticates, authorizes actions, handles replay protection (nonces), and pays fees.
+
+## Aztec Account Details
+*   **Address**: An Aztec address is derived deterministically from the account contract's bytecode and its associated public keys (for encryption, nullification). See [Keys](./../Keys/Keys.md) for more on address derivation.
+*   **Entrypoints**: Account contracts typically have a specific function (often called `entryPoint`) that serves as the main interface for initiating transactions. This function receives actions to perform and an authentication payload (e.g., a signature).
+    *   A typical `entryPoint(payload)` might:
+        1.  Validate the authentication payload (e.g., checks a signature against a stored public key).
+        2.  Iterate through requested private calls and executes them.
+        3.  Iterate through requested public calls and enqueues them.
+*   **Non-Standard Entrypoints**: Since the entrypoint interface isn't strictly enforced by the protocol, contracts can have functions that don't require user authentication and can be called by anyone (e.g., a `claimPrize` function in a lottery). The `msg_sender` will be set accordingly (e.g., to `Field.max` if no contract entrypoint is used, or to the contract making a private-to-public call).
+*   **Coupling with Wallets**: Account contracts are tightly linked to wallet software. The wallet knows how to encode and sign requests for the specific account contract implementation the user has chosen. See [Wallets](./../ExecutionEnvironment/Wallets.md).
+
+## Account Initialization and Deployment
+*   To interact with public state or send transactions *from* an account, its contract must be **deployed**. This involves broadcasting it via the canonical `ContractInstanceDeployer` contract, which also emits a deployment nullifier.
+*   An account contract is **initialized** when one of its functions marked with `#[initializer]` is called. Multiple functions can be initializers. Functions marked `#[noinitcheck]` can bypass this.
+*   **Crucially**: Users can *receive* private [Notes](./../NotesAndUTXOs/Notes.md) (funds) even before their account contract is deployed or initialized because their address is deterministic.
+*   Deployment costs fees, which can be pre-funded to the deterministic address or paid by another account via fee abstraction (see [Transaction Lifecycle](./../TransactionsAndKernels/TransactionLifecycle.md) for fees).
+
+## Complete Address vs. Public Address
+*   **Public Address**: The `x`-coordinate of the `AddressPublicKey` (a Grumpkin elliptic curve point). This is what you share to receive funds.
+*   **Complete Address**: Includes all the user's relevant public keys, a "partial address" (related to contract class and initialization), and the contract address. Needed by the user to *spend* their notes (as it proves ownership of keys).
+
+## Authorizing Actions
+Account contracts are expected (though not protocol-required) to implement methods for authorizing actions on behalf of the user (e.g., allowing another contract to transfer tokens).
+*   **Private Context**: Account contracts can request an **authentication witness (AuthWit)** (e.g., a signature for an action) from the user's [PXE](./../ExecutionEnvironment/PXE.md) via an oracle call. See [Authentication Witness (Authwit)](./AuthWit.md).
+*   **Public Context**: Since the PXE oracle isn't accessible during public execution, account contracts can maintain a public **authwit registry** (in their public storage) for pre-authorized actions.
+*   This allows an account contract to verify `is_valid_impl` (is this action authorized?) in both private and public settings.
+*   *Note on transaction simulations in PXE*: Currently, simulations might not fully anticipate authwit needs, requiring manual provision. This is expected to improve.
+
+## Nonce Abstraction
+*   Developers can customize how nonces (for replay protection) are managed. This allows for flexible transaction ordering, cancellation logic (e.g., by emitting a specific nullifier to cancel a pending tx), etc.
+*   This is particularly relevant for wallet developers, enabling varied transaction priority/cost strategies.
+
+## Fee Abstraction (Paymasters)
+*   **Paymaster Contracts**: Smart contracts that can pay transaction fees on behalf of users.
+*   Invoked during private execution and set as the fee payer.
+*   Can accept fees in any token they're programmed for (e.g., users pay with a stablecoin, paymaster converts and pays fee-juice).
+*   Enables sponsored transactions, private fee payments, etc.
+*   Learn more about fees on the [Transaction Lifecycle](./../TransactionsAndKernels/TransactionLifecycle.md) page.
+
+## Why it Matters for Developers
+*   AA is a powerful paradigm. You can build novel authentication and authorization flows directly into user accounts.
+*   Understanding the `entryPoint` pattern is key for interacting with accounts.
+*   Fee abstraction and nonce abstraction offer significant UX improvements for dapps. 

--- a/session_01/4_AccountsAndAuth/AuthWit.md
+++ b/session_01/4_AccountsAndAuth/AuthWit.md
@@ -1,0 +1,115 @@
+# Authentication Witness (Authwit)
+
+Authentication Witness (Authwit) is a scheme in Aztec for authenticating actions, allowing users to authorize third parties (like protocols or other users) to execute specific actions on their behalf. This is crucial for enabling complex interactions, especially in DeFi, while maintaining user control and security.
+
+## Background: The Challenge of Approvals
+
+In Ethereum's EVM world, contract interactions often involve an `approve` and `transferFrom` pattern for ERC20 tokens. A user first sends an `approve` transaction to the token contract, granting an allowance to another contract (e.g., a DeFi protocol). Then, they call a function on the DeFi protocol, which in turn calls `transferFrom` on the token contract using that allowance.
+
+**Downsides of Traditional EVM Approvals:**
+*   **Two Transactions**: Requires two separate transactions (approve, then the action), which is poor UX.
+*   **Infinite Allowances**: Front-ends often request infinite allowances to avoid repeated approvals, which poses a security risk. If the approved contract is exploited or malicious (especially if upgradeable), it can drain all approved funds without further user interaction.
+*   **Permit (EIP-2612)**: Improves this by allowing off-chain signing of an approval (permit), which is then submitted with the main action in a single transaction. However, this doesn't work well with smart contract wallets (without EIP-1271 adoption) and the signed messages can be opaque to users.
+
+## Authwit in Aztec: A New Approach
+
+Aztec's private state model presents unique challenges for the traditional approval/allowance mechanism. If a protocol has an "allowance" to spend a user's private notes, it doesn't help unless the protocol also knows the details (decryption keys, content) of those private notes, which it shouldn't.
+
+However, Aztec's architecture offers a solution:
+*   **Private Execution on User Device**: Transactions involving private state are executed (and proven) on the user's device via their [PXE](./../ExecutionEnvironment/PXE.md).
+*   **Oracle Calls**: During this private execution, the contract can request additional user-provided information via oracle calls.
+
+**Authwit leverages this**: Instead of an allowance, the user provides a "witness" (which could be a signature, but isn't limited to it) to the contract, authorizing a specific action.
+
+### What is an "Action" in Authwit?
+
+An "action" is a blob of data that precisely specifies:
+*   The **caller** authorized to initiate the action.
+*   The target **contract** to be called.
+*   The **selector** of the function to be called on the target contract.
+*   A **hash of the arguments** (`argsHash`) for that function call.
+
+This is typically represented as a hash:
+`authentication_witness_action = H(caller: AztecAddress, contract: AztecAddress, selector: Field, argsHash: Field)`
+
+**Example**: Alice wants to deposit 1000 tokens into a DeFi contract. The DeFi contract needs to transfer tokens from Alice's account.
+*   The `caller` would be the DeFi contract's address.
+*   The `contract` would be the Token contract's address.
+*   The `selector` would be the `transfer_selector`.
+*   The `argsHash` would be `H(alice_account_address, defi_contract_address, 1000)`. // (Or H(alice_account_address, defi_contract_address, 1000, nonce) for replay protection)
+
+The Authwit effectively says: "DeFi_contract is allowed to call Token_contract.transfer(alice_account, defi_contract, 1000).
+
+### Authwit Flow Diagram
+
+```mermaid
+sequenceDiagram
+    participant User
+    participant PXEWallet as User's PXE/Wallet
+    participant DAppContract as DApp Contract (e.g., DeFi)
+    participant TokenContract as Token Contract
+    participant AccountContract as User's Account Contract
+
+    User->>PXEWallet: Initiate action (e.g., DApp.deposit(1000))
+    PXEWallet->>DAppContract: Prepare DApp.deposit() call
+    Note over PXEWallet,DAppContract: DApp needs to call Token.transferFrom(User, DApp, 1000)
+    
+    PXEWallet->>AccountContract: (Via Oracle during simulation) Request AuthWit for DApp to call Token.transferFrom(User, DApp, 1000)
+    AccountContract->>PXEWallet: User approves; PXE generates AuthWit (e.g., signature over action hash)
+    
+    PXEWallet->>DAppContract: Execute DApp.deposit(1000, generatedAuthWit)
+    DAppContract->>TokenContract: Call Token.transferFrom(User, DApp, 1000, generatedAuthWit)
+    
+    TokenContract->>AccountContract: STATICCALL Account.isValidAuth(actionHash, generatedAuthWit)
+    AccountContract->>AccountContract: Validate witness against actionHash (e.g., verify signature)
+    AccountContract-->>TokenContract: Return true / false
+    
+    alt AuthWit Valid
+        TokenContract->>TokenContract: Perform transfer logic (nullify old notes, create new notes)
+        TokenContract-->>DAppContract: transferFrom successful
+        DAppContract->>DAppContract: Complete deposit logic
+        DAppContract-->>PXEWallet: deposit successful
+    else AuthWit Invalid or other error
+        TokenContract-->>DAppContract: transferFrom failed
+        DAppContract-->>PXEWallet: deposit failed
+    end
+```
+
+**Important Considerations**: 
+*   The call from the TokenContract to the AccountContract to check `isValidAuth` **must be a static call**. This prevents re-entrancy issues where the account contract might try to change state or call back into the token contract unexpectedly during the authorization check.
+*   The witness itself is provided by the PXE through an oracle call during the private execution of the contract that needs to be authenticated (e.g., the TokenContract in the diagram above, if `transferFrom` is private).
+
+### Authwit for Public State Interactions
+
+While oracle calls are for private execution, Authwit can be extended to public state:
+*   Instead of relying on a private oracle call, the Authwit (or a commitment to it) can be stored in a **public shared registry** (e.g., in the AccountContract's public storage).
+*   A public function can then look up this pre-approved Authwit.
+*   This can be done in the same transaction: batch the Authwit update (storing it) with the interaction that consumes it. If set and unset in the same transaction, there might be no net public state change for the authorization itself, potentially saving gas.
+
+### Replay Protection
+
+To ensure an Authwit can only be used once (or a controlled number of times):
+*   The `authentication_witness_action` itself (or its hash) can be **emitted as a nullifier** by the contract that consumes the authorization (e.g., the TokenContract).
+*   This prevents the same exact action from being authenticated twice.
+*   If an action needs to be authorized multiple times, a **nonce** should be included in the arguments when hashing to create the `argsHash`. This makes each `authentication_witness_action` unique.
+    *   Example: `argsHash = H(alice_account, defi_contract, 1000, nonce)`
+*   The AccountContract (which is static_called for `isValidAuth`) cannot emit the nullifier. The calling contract (e.g., TokenContract) is responsible for this, similar to how nonces are handled in some ERC20 permit implementations. Aztec may provide libraries to help manage this.
+
+### Differences from EVM Approvals
+
+*   **Specificity**: Authwit authorizes a *specific action*, not a general allowance. This is more explicit and gives the user clearer insight into what they are approving.
+*   **User-Centric Execution**: For private interactions, the user is already executing the transaction on their device, making the provision of secrets or detailed note information less of a barrier compared to a protocol trying to act on a user's behalf with only an allowance.
+
+**Limitation Note**: Authwits are primarily for a single user authorizing actions on contracts that their account is interacting with. They are not typically used to authorize *other users* to take actions on one's behalf in a way that would require sharing fundamental account secrets like the nullifier secret key.
+
+### Broader Use-Cases
+
+Authwit isn't limited to token transfers. It can be used for any function requiring user authentication, such as:
+*   Authorizing a burn operation.
+*   Approving the movement of assets from public to private state.
+*   Voting in a governance contract.
+*   Performing operations on a lending protocol on behalf of the user.
+
+## Next Steps
+
+Refer to the official Aztec developer documentation to see how to implement and use Authwit patterns in your Aztec.nr smart contracts. 

--- a/session_01/5_Keys/Keys.md
+++ b/session_01/5_Keys/Keys.md
@@ -1,0 +1,84 @@
+# Cryptographic Keys in Aztec
+
+In Aztec, each account is associated with several cryptographic key pairs. These keys are fundamental to the network's privacy, security, and functionality, enabling everything from spending notes to encrypting data and deriving account addresses.
+
+## Types of Keys
+
+Each Aztec account is primarily backed by four types of key pairs. The first three (Nullifier, Address, Incoming Viewing) are deeply embedded into the protocol, while Signing Keys are abstracted to the account contract developer.
+
+### 1. Nullifier Keys
+*   **Pair**: Master Nullifier Public Key (`Npk_m`) and Master Nullifier Secret Key (`nsk_m`).
+*   **Purpose**: Used to spend/consume private [notes](./../NotesAndUTXOs/Notes.md). When a note is spent, its nullifier is revealed, preventing it from being spent again.
+*   **How it works**: To spend a note, the user computes a unique nullifier. This nullifier is typically a hash of the note's commitment (or the note hash itself) and an **app-siloed nullifier secret key**. This app-siloed key is derived using the user's master nullifier secret key (`nsk_m`) and the specific contract address the note is associated with (`nsk_app = H(nsk_m, app_contract_address)`). The protocol ensures that only someone possessing the `nsk_m` (and thus able to derive `nsk_app`) linked to the note owner's address can generate the correct nullifier.
+
+### 2. Address Keys
+*   **Pair**: Address Public Key (`AddressPublicKey`) and Address Secret Key (`address_sk`).
+*   **Purpose**: Primarily used for the derivation of the account's unique address. Also plays a role in note encryption.
+*   **Derivation Details**:
+    *   `AddressPublicKey` is an elliptic curve point `(x,y)` on the Grumpkin curve. The account's human-readable address is typically its `x`-coordinate.
+    *   The `address_sk` is derived from a `pre_address` and the `ivsk_m` (master incoming viewing secret key): `address_sk = pre_address + ivsk_m`.
+    *   `pre_address` itself is a complex hash ensuring the address is tied to the account's keys and contract logic:
+        *   `pre_address := poseidon2(public_keys_hash, partial_address)`
+        *   `public_keys_hash := poseidon2(Npk_m, Ivpk_m, Ovpk_m, Tpk_m)` (where `Ovpk_m` is Master Outgoing Viewing Public Key and `Tpk_m` is Master Tagging Public Key - currently less utilized but formally part of the structure).
+        *   `partial_address := poseidon2(contract_class_id, salted_initialization_hash)`
+        *   `contract_class_id := poseidon2(artifact_hash, fn_tree_root, public_bytecode_commitment)`
+        *   `salted_initialization_hash := poseidon2(deployer_address, salt, constructor_hash)`
+    *   This intricate derivation means an Aztec address commits to the contract's code, its initialization parameters, and the user's core cryptographic keys.
+
+### 3. Incoming Viewing Keys
+*   **Pair**: Master Incoming Viewing Public Key (`Ivpk_m`) and Master Incoming Viewing Secret Key (`ivsk_m`). (Note: The document also mentions `Ovpk_m` - Outgoing Viewing Public Key, which is part of `public_keys_hash` but less emphasized in current primary use cases like note reception).
+*   **Purpose**: `Ivpk_m` (via the derived `AddressPublicKey` of the recipient) is used by a sender to encrypt a note *for* the recipient. The recipient uses their `ivsk_m` (via their `address_sk`) to decrypt the note.
+*   **Encryption/Decryption Flow (Simplified for a note)**:
+    1.  **Sender Side**: To send a note to Recipient:
+        *   Sender generates a random ephemeral key pair (`esk_sender`, `Epk_sender`).
+        *   Sender uses Recipient's `AddressPublicKey` (which is derived using Recipient's `ivsk_m`) and `esk_sender` to compute a shared secret: `S = esk_sender * AddressPublicKey_recipient`.
+        *   A symmetric encryption key is derived from this shared secret: `symmetric_key = hash(S)`.
+        *   The note data is encrypted: `Ciphertext = aes_encrypt(note_data, symmetric_key)`.
+    2.  **Transmission**: Sender transmits `(Epk_sender, Ciphertext)` to the Recipient (e.g., as an encrypted log on-chain).
+    3.  **Recipient Side**: To decrypt:
+        *   Recipient uses their `address_sk` (which incorporates their `ivsk_m`) and the received `Epk_sender` to reconstruct the same shared secret: `S = Epk_sender * address_sk_recipient`.
+        *   Recipient derives the `symmetric_key` from `S`.
+        *   Recipient decrypts the `Ciphertext` using `symmetric_key`.
+
+### 4. Signing Keys (Optional & Abstracted)
+*   **Purpose**: Used for authorizing actions, typically by signing messages or transaction payloads within an [Account Contract](./../AccountsAndAuth/Accounts.md). This is the most "traditional" use of keys for authentication.
+*   **Abstraction**: Due to Aztec's native Account Abstraction, developers are **not forced** to use a specific signature scheme (like ECDSA or Schnorr) or even keys at all for authorization. Account contracts can implement custom logic (e.g., social recovery, multi-factor authentication, passwords, Face ID hooks).
+*   **If Used**: If an account contract uses signature-based authentication, it will manage a signing public key and its entrypoint logic will verify incoming signatures against this stored public key.
+    *   Example from Schnorr Account Contract: `schnorr::verify_signature(pub_key, signature, payload_hash.to_be_bytes::<32>())`
+*   **Storing Signing Public Keys**: Since these are abstracted, the method of storing the public key within the account contract is up to the developer:
+    *   **Private Note**: Allows key rotation. Reading the note (and nullifying it to ensure it's up-to-date) incurs a small overhead per transaction.
+    *   **Immutable Private Note**: No per-transaction overhead for reading, but the key cannot be rotated.
+    *   **Shared Mutable State (Privately Readable, Publicly Mutable)**: Allows rotation but introduces complexities like update delays and time-to-live for transactions based on state update frequency.
+    *   **Reusing In-Protocol Keys (e.g., `Ivpk_m`)**: Possible to validate against the account address (since `Ivpk_m` is part of its preimage). Generally **not recommended** as it reduces key separation and security.
+    *   **Separate Keystore Contract**: A dedicated contract acts as a keystore, and multiple account contracts can check against it for authorization. Incurs higher proving time per transaction but no extra fee cost.
+
+## Key Generation
+*   Nullifier, Address, and Incoming Viewing keys (and their master versions) are typically generated by the user's [PXE](./../ExecutionEnvironment/PXE.md) when an account is created.
+*   The PXE is also responsible for further key management, including oracle access to keys for circuit execution and deriving app-siloed keys.
+
+## Key Derivation Cryptography
+*   Most key pairs (secret key, public key) are derived using elliptic curve cryptography on the **Grumpkin curve**. The secret key is a scalar, and the public key is that scalar multiplied by the curve's generator point `G`.
+*   The `address_sk` is an exception, derived as described in the Address Keys section.
+
+## App-Siloed Keys
+*   **Concept**: Nullifier keys and Incoming Viewing keys are **app-siloed**. This means the actual keys used by a user within a specific application contract are not their master keys directly, but rather keys derived from their master keys *and* that specific application contract's address.
+    *   Example: `nsk_app_A = hash(nsk_m_user, contract_A_address)`
+    *   `ivpk_app_A_recipient = H(ivpk_m_recipient, contract_A_address)` (conceptual)
+*   **Derivation**: This derivation happens within the PXE whenever the user interacts with an application.
+*   **Benefits**:
+    *   **Enhanced Security**: If an app-siloed key is compromised (e.g., due to a vulnerability in one specific app contract), it only affects the user's assets and privacy *within that single application*. Their master keys and their assets in other applications remain secure.
+    *   **Per-Application Auditability/Disclosure**: A user can choose to disclose their app-siloed incoming viewing key for a specific application to a third party (e.g., an auditor, regulator, or a block explorer for display purposes). This reveals all their activity *only within that specific application context*, while preserving their privacy across all other applications on the network.
+
+## Key Rotation
+*   **Impossible for Protocol-Embedded Keys**: Nullifier Keys, Address Keys, and Incoming Viewing Keys **cannot be rotated**. They are fundamentally embedded into the derivation of the account's address, and the address itself is immutable once determined.
+*   **Possible for Signing Keys**: Signing Keys **can be rotated**, provided the account contract is designed to support this (e.g., by storing the signing public key in a mutable private note or a shared mutable state slot).
+
+## Escrow Contracts: A Special Case
+*   Typically, account contracts will have non-zero public keys for these core functions. Non-account (application) contracts usually have zero for these specific protocol-level key fields.
+*   **Exception**: An escrow contract might be an example of a non-account contract that has its own `Npk_m` registered. Notes intended for the escrow would be encrypted to this `Npk_m`.
+*   Participants in the escrow (e.g., parties in a bet) would then need a way to obtain or use the escrow's `nsk_m` (or a derived app-siloed version) to nullify the escrowed notes based on the escrow contract's logic (e.g., providing a "proof of winning").
+
+## Why it Matters for Developers
+*   You generally don't handle these keys directly at the DApp layer; the PXE and account contracts abstract much of their management.
+*   Understanding app-siloing is crucial for appreciating Aztec's security and privacy model.
+*   When designing custom account contracts ([Accounts](./../AccountsAndAuth/Accounts.md)), you have significant choices in how (or if) you implement signing keys, their storage, and their rotation capabilities, directly impacting user security and flexibility. 

--- a/session_01/6_TransactionsAndKernels/KernelCircuits.md
+++ b/session_01/6_TransactionsAndKernels/KernelCircuits.md
@@ -1,0 +1,44 @@
+# Kernel Circuits: The Heart of Transaction Validation
+
+Kernel circuits are fundamental to Aztec's transaction processing. They are responsible for validating the correct execution of function calls within a transaction and managing the transition between private and public execution phases. Aztec employs two main kernel circuits:
+
+1.  **Private Kernel Circuit**
+2.  **Public Kernel Circuit**
+
+A transaction is constructed by generating proofs for potentially multiple recursive iterations of these kernel circuits. Each function call in a transaction's call stack corresponds to a new iteration of a kernel circuit. These calls are managed by FIFO (First-In, First-Out) queues: one for private calls and one for public calls.
+
+One iteration of a kernel circuit will:
+*   Pop a call request from its respective stack.
+*   Execute the call (which for private calls means verifying its associated proof, and for public calls means actual execution or simulation leading to a proof).
+*   If the executed call triggers subsequent contract calls (either private or public), these new calls are pushed onto the appropriate call stack.
+
+## 1. Private Kernel Circuit
+
+*   **Execution Environment**: This circuit is effectively executed by the **user, on their own device** (within their [PXE](./../ExecutionEnvironment/PXE.md)). This is paramount to ensure that all private inputs to the circuit (which includes sensitive user data and contract details) remain confidential.
+*   **Zero-Knowledge Property**: The Private Kernel Circuit is one of the core protocol circuits that **must be truly "zk" (zero-knowledge)**. Its proofs must not leak any information about the witnesses (the private data being processed).
+    *   This private data includes:
+        *   Details of the Aztec.nr contract function being executed.
+        *   The address of the user who executed the function.
+        *   The intelligible (unencrypted) inputs and outputs of that function.
+*   **Distinction from typical "zk-Rollups"**: Many rollups use SNARKs primarily for their succinctness (computation compression) and don't strictly require the zero-knowledge property because they don't handle private user data at this level. Aztec, by processing private data client-side within this circuit, genuinely leverages the "zero-knowledge" aspect of ZK-SNARKs. This is why it's sometimes referred to as a "zk-zk-Rollup" or an "actual zk-Rollup."
+*   **Order of Operations**: Proofs involving the Private Kernel Circuit are generated first. A transaction is ready to move to the public execution phase only when the private call stack is empty.
+
+## 2. Public Kernel Circuit
+
+*   **Execution Environment**: This circuit is executed by a **Sequencer**. Only the Sequencer (or its delegated Provers) knows the current, up-to-date state of the public data tree at any given time, which is necessary for correct public function execution.
+*   **Input**: The Public Kernel Circuit typically takes as input a proof from a Private Kernel Circuit (or another Public Kernel circuit iteration) where the private call stack is now empty.
+*   **Operation**: It operates recursively, processing calls from the public call stack until it is also empty.
+*   **Zero-Knowledge Not Strictly Required (for this circuit's inputs from public state)**: While it processes outputs from the private kernel (which are zk-proven), the public kernel itself, when dealing with public state and public function execution, doesn't inherently need to hide the public data it operates on from the Sequencer/Prover.
+
+## Transaction Completion
+
+A transaction is considered complete and its overall proof finalized when **both the private and public call stacks are empty**.
+
+### Information Leakage
+
+Even with this robust system, some information about the transaction is inevitably revealed (though significantly less than on a transparent L1):
+*   The number of private state updates (new notes, nullifiers) triggered.
+*   The set of public calls that were generated and executed.
+*   The addresses of all *private* calls remain hidden from observers.
+
+(See also [Transaction Lifecycle](./TransactionLifecycle.md) for how these circuits fit into the broader flow.) 

--- a/session_01/6_TransactionsAndKernels/TransactionLifecycle.md
+++ b/session_01/6_TransactionsAndKernels/TransactionLifecycle.md
@@ -1,0 +1,116 @@
+# Transaction Lifecycle in Aztec
+
+**Core Idea**: Aztec transactions are fundamentally different from Ethereum's due to client-side proving for private components and the separation of private/public execution phases.
+
+## Simple Private Transaction Lifecycle Example (e.g., Sending Private DAI)
+
+1.  **User Initiates (in Wallet/DApp)**:
+    *   User confirms an action, e.g., "privately send 10 DAI to `recipient.eth`".
+    *   *Status*: The intent exists only within the user's client-side environment (e.g., [PXE](./../ExecutionEnvironment/PXE.md)).
+
+2.  **PXE Executes Locally (Private Part Simulation & Proving)**:
+    *   The PXE simulates the private function call (e.g., the `transfer` method on the private DAI token contract) using the user's private inputs (notes to spend, keys).
+    *   It computes the state difference: which input notes to consume (and thus nullify), which new output notes to create (for the recipient and any change for the sender).
+    *   The PXE then generates ZK-SNARK proofs for:
+        *   Correct authorization (e.g., proof that the user approved this, often via their [Account Contract](./../AccountsAndAuth/Accounts.md) logic).
+        *   Correct execution of the private `transfer` method according to the contract's circuit.
+    *   *Status*: Proofs and public outputs (new note commitments, nullifiers) are generated locally. Private inputs never leave the PXE.
+
+3.  **Transaction Sent to Network (via Aztec Node)**:
+    *   The PXE sends the ZK proofs, new note commitments, nullifiers, and any requests for public function execution (if applicable) to an Aztec Node.
+    *   *Status*: The transaction, or at least its private components and effects, is now known to an Aztec Node.
+
+4.  **Sequencer Processing & Block Inclusion**:
+    *   The Aztec Node relays the transaction to a Sequencer.
+    *   The Sequencer:
+        *   Validates the ZK proofs for the private execution part.
+        *   If there are enqueued public functions, the Sequencer executes them. If these public functions require their own proofs (e.g., for complex state changes), the Sequencer might request these from a Prover network.
+        *   Updates its local view of the L2 state trees (adds new note commitments, records nullifiers).
+        *   Bundles this transaction with others into a block.
+        *   Generates (or coordinates generation of) a final rollup proof for the entire block, attesting to the validity of all included state transitions (both private and public).
+    *   *Status*: Transaction is included in an L2 block, ready for L1 settlement.
+
+5.  **Settlement on L1 (Ethereum)**:
+    *   The Sequencer (or a designated Prover) submits the rollup proof for the L2 block to the Verifier contract on Ethereum (L1).
+    *   The L1 Verifier contract validates this rollup proof.
+    *   If valid, the L1 Rollup contract records the new L2 state root (and other relevant data like L1-L2 message roots).
+    *   *Status*: The L2 transaction is now final and settled on L1. Its effects are globally consistent.
+
+## Transaction Requests (`TxRequest` in `aztec.js`)
+
+This object, typically constructed by `aztec.js` or similar client libraries, encapsulates the user's intent for a transaction. Key fields often include:
+*   `origin`: The [Account Contract](./../AccountsAndAuth/Accounts.md) address from which the transaction is initiated.
+*   `functionData`: Contains details like the function selector and whether the function is private or public.
+*   `argsHash`: A hash of all the arguments for the function calls to be executed. The full arguments are passed to the PXE and checked against this hash during simulation.
+*   `txContext`: Contains chain ID, protocol version, and gas settings.
+*   `salt`: A random value used, among other things, to make the first nullifier (if one is implicitly generated) difficult to predict.
+
+An account contract validates that the transaction request has been authorized (e.g., via a signature check in its entrypoint function).
+
+## Contract Interaction Methods (in `aztec.js`)
+
+`aztec.js` provides methods on contract objects to build and send transactions:
+*   `.create()`: Creates a `TxExecutionRequest` object, which is an authenticated request ready for simulation by the PXE.
+*   `.simulate()`: Simulates the transaction locally (private execution, and optionally public as well if requested and feasible for simulation). Returns the function's return values. Does *not* generate a proof or send to the network.
+*   `.prove()`: Simulates the transaction, then generates the ZK proofs for the private part of the execution. Returns a `ProvenTx` object containing these proofs and public inputs. Does *not* send to the network.
+*   `.send()`: Simulates, proves, and then sends the `ProvenTx` to an Aztec Node to be broadcast and included in a block. Returns a `SentTx` object for tracking the transaction's status and receipt.
+
+## Batch Transactions
+
+Aztec.js supports batching multiple function calls originating from a single wallet/account into a single L2 transaction. This allows for more complex atomic operations.
+
+## Fees
+
+Transaction fees in Aztec are designed to cover:
+*   **L1 Costs**: Ethereum execution of a block (verifying rollup proof) and data availability (e.g., via blobs for L2 block data).
+*   **L2 Node Operating Costs**: Including the computational cost of proving by Sequencers/Provers.
+
+**Key Terminology & Concepts**:
+*   **`mana`**: Analogous to Ethereum's `gas`; a unit of computational effort.
+*   **`fee-juice per mana`**: Analogous to `gas price`.
+*   **`fee-juice`**: The actual amount paid for the transaction (the native fee asset of Aztec).
+*   **Oracle for Pricing**: An oracle informs the `fee-juice per wei` price, allowing conversion to familiar L1 terms.
+*   **EIP-1559 Influence**: Aztec may incorporate concepts like congestion multipliers and base/priority fees per mana.
+
+**User Gas Settings (`GasSettings` in `aztec.js`)**: Users can specify limits for:
+*   `gasLimits`: Data Availability (DA) and L2 execution gas limits.
+*   `teardownGasLimits`: DA and L2 gas limits for an optional transaction teardown phase.
+*   `maxFeesPerGas`: Maximum DA and L2 fees-per-gas the user is willing to pay.
+*   `maxPriorityFeesPerGas`: Maximum priority DA and L2 fees-per-gas.
+
+**Fee Payment Mechanisms**:
+*   **Direct Payment**: Users can bridge the native `fee-juice` asset from L1. On L2, this asset is non-transferable by users and is only deducted by the protocol to pay for fees.
+*   **Fee Paying Contracts (FPCs)**: Enable fee abstraction. These are smart contracts that can pay transaction fees on behalf of users. Users might interact with an FPC by paying it in a different token (e.g., a stablecoin), and the FPC then pays the `fee-juice` to the protocol. FPCs can have custom logic for authorizing fee payments (publicly or privately).
+
+**Teardown Phase**: An optional phase in public execution where the transaction fee amount is available to public functions. This is useful for contracts that need to compute refunds or implement complex fee abstraction logic.
+
+**Operator Rewards**: Collected `fee-juice` from transactions is pooled. After an epoch is proven, this pool (minus any burnt due to congestion) is distributed to Provers and Sequencers who contributed to that epoch.
+
+(See also [Kernel Circuits](./KernelCircuits.md) for the role of kernel circuits in transaction validation.)
+
+### Diagram: Simplified Transaction Flow
+```mermaid
+graph LR
+    subgraph UserDevice [User's Device (PXE)]
+        A[User Action in DApp/Wallet] --> B{Contract Interaction Call (.send())};
+        B --Function Details, Args--> C[PXE Simulates & Proves Private Execution];
+        C --Proven Private Part, Public Call Requests, Nullifiers, New Notes--> D[Tx Payload];
+    end
+
+    D --To Network--> E[Aztec Node];
+    E --> F[Sequencer];
+
+    subgraph SequencerProverNet [Sequencer/Prover Network]
+        F --Validates Private Proofs--> G[Process Private State Updates];
+        G --Public Call Requests--> H[Execute Public Functions & Generate Public Proofs (if any)];
+        H --Proven Public Part--> I[Assemble L2 Block];
+        I --Rollup Proof & Block Data--> J[L1 Rollup Contract on Ethereum];
+    end
+    
+    J --Verify Proof & Update L2 State Root--> K[Transaction Settled on L1];
+```
+
+## Why it Matters for Developers
+*   The client-side proving model is a fundamental shift from traditional blockchains.
+*   Understanding the `aztec.js` contract interaction flow (`.create()`, `.simulate()`, `.prove()`, `.send()`) is essential for DApp development.
+*   Fee mechanisms, especially Fee Paying Contracts (FPCs), offer significant flexibility for improving user experience regarding transaction costs. 

--- a/session_01/7_ContractCalls/CallTypes.md
+++ b/session_01/7_ContractCalls/CallTypes.md
@@ -1,0 +1,70 @@
+# Call Types: How Contracts Talk to Each Other
+
+Aztec contracts can call functions on other contracts, and these interactions can cross privacy boundaries (private to public, public to private). Understanding the different call types is crucial for designing secure and efficient applications.
+
+## Context: Private and Public Execution
+
+*   **Private Functions**: Executed and proven client-side (in the user's [PXE](./../ExecutionEnvironment/PXE.md)). They operate on private state and can call other private functions or enqueue calls to public functions.
+*   **Public Functions**: Executed and proven by the network Sequencer. They operate on public state and can call other public functions or enqueue calls to private functions.
+
+## Types of Contract Calls
+
+### 1. Private-to-Private Calls
+*   **How it works**: A private function in Contract A calls a private function in Contract B.
+*   **Execution**: Both functions are executed and proven client-side within the same transaction's private phase.
+*   **Data Flow**: Private data can be passed between these functions directly within the client-side execution environment.
+*   **Atomicity**: If one call fails, the entire private portion of the transaction typically fails.
+
+### 2. Private-to-Public Calls
+*   **How it works**: A private function in Contract A calls (enqueues a request for) a public function in Contract B.
+*   **Execution**: The private function (A) is proven client-side. The public function (B) is executed by the Sequencer later, when the transaction is processed.
+*   **Data Flow**: Data from the private function to the public function must be passed as public inputs/arguments. The private function cannot directly see the return value of the public function within the same transaction because of the asynchronous execution.
+    *   **Analogy**: Sending a letter (private call with its data) to a public office (public function). The office processes it later. You don't get an immediate response in your private context.
+*   **Security**: The private function proves it has correctly formed the request for the public call.
+
+### 3. Public-to-Public Calls
+*   **How it works**: A public function in Contract A calls a public function in Contract B.
+*   **Execution**: Both functions are executed by the Sequencer during the public phase of transaction processing.
+*   **Data Flow**: Data can be passed directly, and return values are immediately available.
+*   **Atomicity**: If one call fails, the relevant public portion of the transaction typically fails.
+
+### 4. Public-to-Private Calls
+*   **How it works**: A public function in Contract A calls (enqueues a request for) a private function in Contract B.
+*   **Execution**: The public function (A) is executed by the Sequencer. The request for the private function (B) is then picked up by the recipient's PXE in a subsequent block/process.
+*   **Data Flow**: Data from the public function to the private function must be passed in a way that the recipient's PXE can identify and use to initiate the private execution (e.g., as parameters in an encrypted log or event that the PXE is scanning for).
+    *   **Analogy**: A public office (public function) posts a sealed, addressed task (request for private call) on a public board. Only the intended recipient (user's PXE) can open and act on it later.
+*   **Asynchronous & User-Initiated**: This is highly asynchronous. The private call won't happen until the user's PXE detects the request and initiates a new transaction to execute that private function.
+*   **Return Values**: The public function cannot directly receive a return value from the private function in the same transaction.
+
+## Diagram: Call Type Interactions
+
+```mermaid
+graph TD
+    subgraph ClientDevice [User's Device (PXE)]
+        P1["Private Fn (Contract A)"]
+        P2["Private Fn (Contract B)"]
+    end
+
+    subgraph SequencerNetwork [Sequencer/Network]
+        U1["Public Fn (Contract C)"]
+        U2["Public Fn (Contract D)"]
+    end
+
+    P1 -- "1. Private-to-Private" --> P2;
+    P1 -- "2. Private-to-Public (Enqueue)" --> U1;
+    U1 -- "3. Public-to-Public" --> U2;
+    U1 -- "4. Public-to-Private (Enqueue/Event)" --> P1_Future["Future Private Fn (Contract A) - User Initiated"];
+    
+    style P1_Future fill:#eee,stroke:#333,stroke-width:2px,color:#333,stroke-dasharray: 5 5;
+    P1_Future -.-> ClientDevice;
+```
+*(Note: The diagram simplifies by showing Contract A's private function being called back; it could be any private function on any contract intended for that user.)*
+
+## Key Considerations for Developers
+
+*   **Asynchronicity**: Calls between private and public contexts are generally asynchronous. Design your application logic to handle this, often using a multi-transaction workflow for request/response patterns across privacy domains.
+*   **Data Passing**: Carefully consider how data is passed, especially for private-to-public (data becomes public) and public-to-private (data needs to be securely and discoverably passed to the recipient for their PXE to act on).
+*   **State Consistency**: The public state is updated by the Sequencer. Private state is managed client-side and its commitments/nullifiers are submitted. Understand how these interact, especially when a private function relies on some public state or vice-versa.
+*   **Gas and Proving Costs**: Different call types and the complexity of the functions involved will have different implications for proving time (client-side for private, sequencer-side for public) and transaction fees.
+
+(See also [Kernel Circuits](./../TransactionsAndKernels/KernelCircuits.md) for how calls are managed internally.) 

--- a/session_01/8_CommunicationLayers/L1L2Portals.md
+++ b/session_01/8_CommunicationLayers/L1L2Portals.md
@@ -1,0 +1,91 @@
+# L1-L2 Communication (Portals)
+
+Aztec, as a Layer 2 (L2) network, needs robust mechanisms to communicate with Layer 1 (L1), which is typically Ethereum. This communication is vital for bridging assets, relaying messages, and synchronizing state. Aztec achieves this through **Portals**.
+
+**Analogy**: Think of Portals as secure, bi-directional communication channels or bridges connecting the Aztec L2 to the Ethereum L1.
+
+## What are Portals?
+*   Portals are special smart contracts that exist on both L1 and L2.
+*   They facilitate the transfer of messages and assets between the two layers.
+*   The L1 portal contract can call functions on the L2 portal contract, and vice-versa.
+
+## Key Functions of Portals
+
+### 1. Bridging Assets
+*   **L1 to L2 (Deposits)**:
+    1.  A user interacts with an L1 portal contract associated with a specific asset (e.g., an ERC20 token like DAI).
+    2.  They typically lock their L1 assets in this L1 portal contract.
+    3.  The L1 portal contract emits an L1 event (a message) that signals to the Aztec network that assets have been locked.
+    4.  This message is picked up by Aztec Sequencers.
+    5.  The Sequencer includes this message in an L2 block.
+    6.  The corresponding L2 portal contract (or another designated L2 contract) receives this message and mints equivalent private L2 assets (e.g., PrivateDAI notes) to the user's Aztec account.
+    *   **Security**: The L1 portal ensures assets are genuinely locked before signaling L2. The L2 side verifies the message originated from the legitimate L1 portal.
+*   **L2 to L1 (Withdrawals)**:
+    1.  A user initiates a withdrawal from their L2 private assets via an L2 contract (often interacting with an L2 portal).
+    2.  The L2 assets are typically burned (or transferred to an L2 holding address).
+    3.  The L2 contract (e.g., L2 portal) sends a message out to L1.
+    4.  This message is included in an L2 block and eventually relayed to the L1 Rollup contract.
+    5.  The L1 Rollup contract makes this message available/consumable on L1.
+    6.  The user (or a relayer) can then present proof of this L2 message to the L1 portal contract.
+    7.  The L1 portal contract verifies the message and releases the corresponding L1 assets to the user on L1.
+    *   **Security**: The L2 side ensures assets are burned/secured before signaling L1. The L1 portal verifies the legitimacy of the withdrawal message from L2 (via Merkle proofs against the L2 state committed to L1).
+
+### 2. Relaying Messages (Arbitrary Data)
+*   Portals aren't just for assets. They can relay arbitrary messages between L1 and L2 contracts.
+*   This allows for cross-chain governance, state synchronization, or triggering actions on one layer based on events on the other.
+    *   **Example**: An L1 DAO could vote on a proposal, and the result (a message) could be sent through a portal to an L2 contract to execute a change based on that vote.
+
+## Diagram: L1-L2 Asset Bridging via Portal
+
+```mermaid
+graph TD
+    subgraph Ethereum_L1 [Ethereum (L1)]
+        UserL1[User on L1]
+        L1Portal[L1 Portal Contract (e.g., DAI Portal)]
+        L1ERC20[L1 DAI Token Contract]
+        L1Rollup[Aztec L1 Rollup Contract]
+    end
+
+    subgraph Aztec_L2 [Aztec (L2)]
+        UserL2[User on L2]
+        L2Portal[L2 Portal Contract (e.g., PrivateDAI Portal)]
+        L2PrivateDAI[L2 PrivateDAI Contract/Notes]
+        Sequencer[Aztec Sequencer]
+    end
+
+    %% L1 to L2 Deposit
+    UserL1 -- 1. Approves & Calls deposit() --> L1Portal;
+    L1Portal -- 2. Locks L1 DAI (transfers from UserL1) --> L1ERC20;
+    L1Portal -- 3. Emits L1->L2 Message (DepositInfo) --> L1Rollup;
+    L1Rollup -- 4. Message included in L2 batch --> Sequencer;
+    Sequencer -- 5. Relays message to L2 --> L2Portal;
+    L2Portal -- 6. Mints PrivateL2DAI to UserL2 --> L2PrivateDAI;
+    UserL2 -- Receives L2 Assets --> L2PrivateDAI;
+
+    %% L2 to L1 Withdrawal (Simplified)
+    UserL2 -- "A. Initiates withdrawal (burns L2 assets)" --> L2Portal;
+    L2Portal -- "B. Sends L2->L1 Message (WithdrawalInfo)" --> Sequencer;
+    Sequencer -- "C. Message included in L2 block, root published" --> L1Rollup;
+    UserL1 -- "D. Proves L2 message to L1Portal (via L1Rollup state)" --> L1Portal;
+    L1Portal -- "E. Releases L1 DAI to UserL1" --> L1ERC20;
+```
+
+## Technical Details
+
+*   **Message Trees**: Messages between L1 and L2 are often organized into Merkle trees (e.g., an L1->L2 message tree and an L2->L1 message tree). The roots of these trees are periodically committed to the other layer.
+    *   This allows for efficient proof that a specific message was indeed sent and is part of the agreed-upon communication batch.
+*   **`outbox` and `inbox`**: The L1 Rollup contract usually maintains an `outbox` (for L2->L1 messages) and an `inbox` (for L1->L2 messages) represented by these Merkle roots.
+*   **Consumption**: A message can typically only be consumed once to prevent replay attacks.
+
+## Security Considerations
+
+*   **Portal Contract Security**: The Portal contracts themselves must be secure, as they control the locking/unlocking of assets and the validation of messages.
+*   **Message Integrity and Authenticity**: Ensuring that messages haven't been tampered with and originate from the correct source portal is critical.
+*   **Relayer Incentives (for L2->L1 messages)**: While users can often consume their own L2->L1 messages on L1, sometimes relayers are used. The system needs to ensure relayers are properly incentivized and act honestly.
+
+## Why it Matters for Developers
+*   Portals are the primary mechanism for bringing liquidity and data into and out of the Aztec L2.
+*   If your DApp needs to interact with L1 assets or L1 contracts, you will likely be interacting with or building on top of Portal contracts.
+*   Understanding the asynchronous nature and the message-passing mechanics of portals is key to designing robust cross-layer applications.
+
+(See also [Private/Public Calls within L2](./PrivatePublicCalls.md) for communication purely within Aztec.) 

--- a/session_01/8_CommunicationLayers/PrivatePublicCalls.md
+++ b/session_01/8_CommunicationLayers/PrivatePublicCalls.md
@@ -1,0 +1,89 @@
+# Private/Public Calls within L2
+
+While [L1-L2 Portals](./L1L2Portals.md) manage communication between Ethereum and Aztec, equally important is how different execution contexts *within* Aztec L2 interact. Aztec's hybrid state model means contracts have both private and public functions, and they often need to call each other.
+
+**Recap of Execution Contexts:**
+*   **Private Execution**: Happens on the user's device within their [Private Execution Environment (PXE)](./../ExecutionEnvironment/PXE.md). Involves user's private data, private state, and client-side ZK proof generation.
+*   **Public Execution**: Happens on the Sequencer's infrastructure. Involves public state and is verified by the network.
+
+## Communication Pathways (Call Types Revisited)
+
+The primary ways these contexts interact are through specific [Call Types](./../ContractCalls/CallTypes.md):
+
+### 1. Private-to-Private Calls
+*   **Context**: Entirely within the user's PXE (client-side).
+*   **Mechanism**: A private function in Contract A directly calls a private function in Contract B.
+*   **Data Flow**: Synchronous. Arguments and return values are passed directly within the private execution simulation. All data remains private to the user.
+*   **Atomicity**: Forms a single atomic unit within the private phase of the transaction.
+*   **Example**: A private DeFi aggregator calls a private function on a private AMM contract to get a quote, all within the user's simulation before any proof is generated for the sequence.
+
+### 2. Private-to-Public Calls
+*   **Context**: Initiated client-side (PXE), completed by the Sequencer.
+*   **Mechanism**: A private function in Contract A *enqueues a request* for a public function in Contract B to be executed.
+*   **Data Flow**: Asynchronous.
+    *   The private function provides arguments for the public call. These arguments become public data.
+    *   The private function *cannot* directly receive a return value from the public function in the same transaction because the public function executes later on the Sequencer.
+    *   If a result from the public call is needed back in a private context, it typically involves a subsequent transaction or a mechanism where the public function emits an event/log that the user's PXE can later pick up and use to initiate a new private transaction.
+*   **Kernel Interaction**: The [Private Kernel Circuit](./../TransactionsAndKernels/KernelCircuits.md) processes the private call and adds the public call request to a public call stack. The [Public Kernel Circuit](./../TransactionsAndKernels/KernelCircuits.md) later processes this stack.
+*   **Example**: A user privately votes on a proposal (private function). This private function then makes a public call to a governance contract to increment a public vote counter for that proposal.
+
+### 3. Public-to-Public Calls
+*   **Context**: Entirely within the Sequencer's execution environment.
+*   **Mechanism**: A public function in Contract A directly calls a public function in Contract B.
+*   **Data Flow**: Synchronous. Arguments and return values are passed directly. All data is public.
+*   **Atomicity**: Forms a single atomic unit within the public phase of the transaction.
+*   **Example**: A public governance contract, after tallying votes, calls a public function on a treasury contract to release funds.
+
+### 4. Public-to-Private Calls
+*   **Context**: Initiated by the Sequencer, completed client-side (PXE) in a *future* transaction.
+*   **Mechanism**: A public function in Contract A *emits data or an event* (e.g., an encrypted log with a specific tag) that signals a request for a private function in Contract B (belonging to a specific user) to be executed.
+*   **Data Flow**: Highly asynchronous and indirect.
+    *   The public function outputs data intended for the private call (e.g., parameters, a callback identifier).
+    *   This data must be findable and interpretable by the target user's PXE (e.g., through [Note Discovery](./../NotesAndUTXOs/NoteDiscovery.md) mechanisms if it involves creating a note for the user, or by scanning for specific events).
+    *   The target user's PXE, upon discovering this request, must then construct and initiate a *new transaction* to execute the requested private function.
+    *   The public function that initiated the request cannot get a direct return value from this subsequent private execution.
+*   **Analogy**: A public announcement system (public function) leaves a coded, sealed message on a public bulletin board for a specific individual. That individual (user's PXE) must find the message, decode it, and then decide to act on it privately later.
+*   **Example**: An L2 airdrop contract (public function) wants to distribute private tokens to eligible users. It might emit encrypted logs, each containing the airdrop details for a specific user. The user's PXE detects the log addressed to them and then initiates a private transaction to claim these tokens into their private balance.
+
+## Diagram: Intra-L2 Communication Flow
+
+```mermaid
+graph TD
+    subgraph UserPXE [User's PXE - Client-Side]
+        direction LR
+        PrivA1["Private Fn (Contract A)"] -- Private-to-Private --> PrivB1["Private Fn (Contract B)"]
+        PrivA1 -- Private-to-Public (Enqueue) --> PubKernelIn[Public Call Request]
+    end
+
+    subgraph Sequencer [Sequencer - Network-Side]
+        direction LR
+        PubKernelOut[Public Call Request] --> PubC1["Public Fn (Contract C)"]
+        PubC1 -- Public-to-Public --> PubD1["Public Fn (Contract D)"]
+        PubC1 -- Public-to-Private (Emit Event/Log) --> EventForUser[Event/Encrypted Log for UserX]
+    end
+    
+    PubKernelIn --> PubKernelOut
+
+    subgraph UserPXE_Future [UserX's PXE - Future Transaction]
+        direction LR
+        EventForUserDiscovered[PXE Discovers Event/Log] --> PrivA2_Claim["Private Fn (e.g., Claim in Contract A)"]
+    end
+
+    EventForUser -.-> EventForUserDiscovered
+
+    note right of UserPXE : Initial Transaction: Private Phase
+    note right of Sequencer : Initial Transaction: Public Phase (later)
+    note right of UserPXE_Future : Subsequent Transaction by UserX
+```
+
+## Key Design Patterns & Considerations
+
+*   **State Oracle / View Functions**: Often, a private function might need to read public state. This is typically done by the PXE querying an Aztec Node for the relevant public state *before* the private simulation begins, and then feeding this public state as an input to the private circuit. The private circuit then asserts that the provided public state matches a known public state root.
+*   **Callback Mechanisms**: For scenarios requiring a "response" from a public action back to a private context (or vice-versa), developers usually need to implement a multi-step, multi-transaction process:
+    1.  Tx1: Private function makes a request to a public function and potentially stores a unique ID.
+    2.  Tx1 (Public Phase): Public function executes, does its work, and emits an event including the unique ID and the result.
+    3.  Tx2 (Later): User's PXE detects the event, matches the ID, and initiates a new private transaction that consumes the result.
+*   **Synchronicity Assumptions**: Never assume synchronous data return when crossing the private/public boundary within the same transaction. Design for eventual consistency and message passing.
+*   **Gas & Proving Implications**: Private-to-public calls involve client-side proving for the private part and sequencer-side execution for the public part. Public-to-private calls are more complex, involving sequencer execution, event emission, client-side discovery, and then a full new client-side transaction.
+
+Understanding these internal L2 communication flows is essential for building complex, hybrid private/public applications on Aztec. 

--- a/session_01/INTRODUCTION_START_HERE/README.md
+++ b/session_01/INTRODUCTION_START_HERE/README.md
@@ -1,0 +1,41 @@
+# Aztec Concepts: A Deep Dive for Builders
+
+Welcome to this collection of notes on core Aztec Network concepts. These documents aim to provide simplified yet detailed explanations, using analogies, examples, and diagrams to make complex topics more accessible for developers.
+
+**Source**: Primarily based on information from the official Aztec documentation and user-provided materials. For the most current and in-depth details, always refer to the [official Aztec documentation](https://docs.aztec.network/).
+
+## Table of Contents
+
+### 1. State & Storage
+*   [State Model](./../StateAndStorage/StateModel.md)
+*   [Storage Slots](./../StateAndStorage/StorageSlots.md)
+
+### 2. Notes, UTXOs, and Data Management
+*   [Notes (UTXOs)](./../NotesAndUTXOs/Notes.md)
+*   [Note Discovery](./../NotesAndUTXOs/NoteDiscovery.md)
+*   [Nullifier Trees (Indexed Merkle Trees)](./../NotesAndUTXOs/NullifierTrees.md)
+
+### 3. Execution Environment
+*   [Wallets](./../ExecutionEnvironment/Wallets.md)
+*   [Private Execution Environment (PXE)](./../ExecutionEnvironment/PXE.md)
+*   [ACIR Simulator](./../ExecutionEnvironment/ACIRSimulator.md)
+
+### 4. Accounts & Authentication
+*   [Accounts (Native Account Abstraction)](./../AccountsAndAuth/Accounts.md)
+*   [Authentication Witness (Authwit)](./../AccountsAndAuth/AuthWit.md)
+
+### 5. Cryptographic Keys
+*   [Keys](./../Keys/Keys.md)
+
+### 6. Transactions & Kernel Logic
+*   [Transaction Lifecycle](./../TransactionsAndKernels/TransactionLifecycle.md)
+*   [Kernel Circuits](./../TransactionsAndKernels/KernelCircuits.md)
+
+### 7. Contract Call Mechanics
+*   [Call Types](./../ContractCalls/CallTypes.md)
+
+### 8. Communication Layers
+*   [L1-L2 Communication (Portals)](./../CommunicationLayers/L1L2Portals.md)
+*   [Private/Public Calls within L2](./../CommunicationLayers/PrivatePublicCalls.md)
+
+Happy building on Aztec!  gAZTEC


### PR DESCRIPTION
This pull request significantly restructures the Aztec concept documentation within session_01/ for improved readability and maintainability.

New Content Integration: Incorporated new detailed explanations for several advanced Aztec concepts:

Private Execution Environment (PXE)
ACIR Simulator
Storage Slots (Public and Private)
Indexed Merkle Trees (Nullifier Trees)
Note Discovery (Tagging)
Authentication Witness (Authwit)
Kernel Circuits (Private and Public)

Improved Navigation: A main README.md has been added in session_01/Introduction/ to serve as a table of contents, linking to all individual concept files.

GitHub-Friendly Diagrams: All Mermaid diagrams have been updated to ensure they render correctly on GitHub.