### PR TITLE
feat: Add educational content for Session 3 on Aztec

### DIFF
--- a/session_2/04_deep_dive_aztec_events.md
+++ b/session_2/04_deep_dive_aztec_events.md
@@ -1,0 +1,105 @@
+# Deep Dive: Aztec's Event System (Logs)
+
+A common question from developers familiar with Solidity is whether Aztec has an equivalent to `events`. The answer is yes, and Aztec's implementation is arguably even more powerful, as it integrates directly with the network's privacy features.
+
+In Aztec, events are referred to as **logs**. They allow smart contracts to communicate information about their execution to the outside world. Crucially, Aztec supports both **public (unencrypted) logs** and **private (encrypted) logs**.
+
+This capability is documented in the official Aztec documentation. The primary source for this information can be found on the **[Testing Aztec.nr contracts with TypeScript](https://docs.aztec.network/developers/guides/js_apps/test#logs)** page, which states:
+
+> "You can check the logs of events emitted by contracts. Contracts in Aztec can emit both encrypted and unencrypted events."
+
+A practical example of querying these logs is also available in the **[Contract Interaction Tutorial](https://docs.aztec.network/developers/tutorials/codealong/js_tutorials/simple_dapp/contract_interaction)**.
+
+---
+
+## How Events Work in Aztec
+
+Let's break down how to define and use events in an Aztec contract, using examples from the `Token.nr` contract created in Session 3.
+
+### 1. Defining Events in Noir
+
+Events are defined as `structs` within your Noir contract. You can define as many as your application requires.
+
+For example, in the full-stack dApp, we defined a `Transfer` event to log the details of a token transfer.
+
+```rust
+// From: session_3/aztec_app_token/contracts/token_contract/src/main.nr
+
+// ... existing code ...
+
+struct Transfer {
+    from: AztecAddress,
+    to: AztecAddress,
+    amount: Field,
+}
+
+// ... existing code ...
+```
+
+### 2. Emitting Events
+
+You emit events from within your contract's functions using the `emit_unencrypted_log` function, which is available in the `context`.
+
+The `context` is passed as the first argument to any external function. The event struct is then passed to the logging function.
+
+```rust
+// From: session_3/aztec_app_token/contracts/token_contract/src/main.nr
+
+// ... existing code ...
+
+    unconstrained fn transfer(
+        context: &mut PrivateContext,
+        from: AztecAddress,
+        to: AztecAddress,
+        amount: Field,
+        nonce: Field,
+    ) -> pub fn(Context) -> bool {
+        // ... function logic ...
+
+        let event = Transfer { from, to, amount };
+        context.emit_unencrypted_log(&event);
+
+        // ... rest of function ...
+    }
+
+// ... existing code ...
+```
+
+### 3. Querying Logs with Aztec.js
+
+Once a transaction is mined, you can query the logs it produced from your client-side TypeScript/JavaScript application using the PXE (Private Execution Environment).
+
+The `getPublicLogs` method allows you to filter logs, for instance, by the block number in which your transaction was included.
+
+```typescript
+// From: session_3/aztec_app_token/src/scripts/index.ts
+
+// ... existing code ...
+
+  console.log("⏳ Waiting for transaction to be mined...");
+  const receipt = await tx.wait();
+
+  // We can retrieve the logs emitted by our contract
+  if (receipt.status === "mined") {
+    console.log("✅ Transaction mined!");
+    const logs = (await pxe.getPublicLogs({ fromBlock: receipt.blockNumber! })).logs;
+    const transferLog = logs.find(log => {
+      try {
+        // We need to decode the log from our event struct
+        return Transfer.fromBuffer(log.log.data).amount === amount;
+      } catch (e) {
+        return false;
+      }
+    });
+
+    if (transferLog) {
+      const decodedLog = Transfer.fromBuffer(transferLog.log.data);
+      console.log(
+        `🎉 Transfer Log Found: From ${decodedLog.from.toString()} to ${decodedLog.to.toString()} for ${decodedLog.amount} tokens`
+      );
+    }
+  }
+// ... existing code ...
+```
+
+This example demonstrates the end-to-end flow: defining an event, emitting it during a transaction, and then decoding and verifying it on the client. This powerful logging mechanism is essential for building transparent, auditable, and interactive dApps on Aztec. 

--- a/session_3/1-Private-Voting-Contract/EXPLAINED.md
+++ b/session_3/1-Private-Voting-Contract/EXPLAINED.md
@@ -1,0 +1,162 @@
+# Deep Dive: The Private Voting Contract Explained
+
+Welcome, builders! This document breaks down the `EasyPrivateVoting` contract line-by-line. We'll explore the core concepts of Aztec that make private voting possible, using analogies and comparisons to the EVM world you're familiar with.
+
+## The Big Picture: How it Works
+
+Imagine a traditional voting booth. You enter, your name is checked off a list (so you can't vote again), you cast your vote secretly, and you leave. Your vote is then added to a public tally board.
+
+Our `EasyPrivateVoting` contract mimics this:
+1.  **Private Vote (`cast_vote`)**: You call this function. It happens inside your "private booth" (your local PXE).
+2.  **Check-off List (Nullifier)**: The contract generates a unique, anonymous "used-vote ticket" (a nullifier) from your private identity. It "posts" this ticket to a global board of used tickets. If you try to vote again, the system sees your ticket is already on the board and rejects your vote. Crucially, no one can link the ticket back to you.
+3.  **Secret Tally Update (`enqueue`)**: Your private vote doesn't directly touch the public tally. Instead, you secretly pass a message to the "tally master" (the public part of the Aztec network) saying, "add one vote for candidate X."
+4.  **Public Tally (`add_to_tally_public`)**: The tally master receives the message and publicly updates the vote count for candidate X on the main board.
+
+---
+
+## Code Breakdown
+
+### `src/main.nr`
+
+#### Imports
+
+```rust
+use dep::aztec::macros::aztec;
+
+#[aztec]
+pub contract EasyPrivateVoting {
+    use dep::aztec::{
+        keys::getters::get_public_keys,
+        macros::{functions::{initializer, internal, private, public, utility}, storage::storage},
+    };
+    use dep::aztec::prelude::{AztecAddress, Map, PublicImmutable, PublicMutable};
+    use dep::aztec::protocol_types::traits::{Hash, ToField};
+
+    // ... rest of the contract
+}
+```
+
+-   `#[aztec]`: This is a special instruction (a macro) for the Noir compiler. It says, "Hey, this isn't just regular code; it's an Aztec smart contract. Please enable all the special Aztec features like `context`, `storage`, etc."
+-   `use dep::aztec::{...}`: These lines are like `import` statements in JavaScript or Solidity. We're pulling in all the tools we need from the Aztec library.
+    -   `get_public_keys`: A helper to get public key information linked to an address, crucial for creating secure nullifiers.
+    -   `macros::{...}`: These are the decorators (`#[private]`, `#[public]`, etc.) that define what kind of function we're writing.
+    -   `prelude::{...}`: The "prelude" contains the most common data types you'll need:
+        -   `AztecAddress`: Like an `address` in Solidity.
+        -   `Map`: Like a `mapping` in Solidity.
+        -   `PublicMutable`: A public state variable that can be changed (Mutable).
+        -   `PublicImmutable`: A public state variable that can be set only once (Immutable).
+    -   `traits::{Hash, ToField}`: Helpers for cryptographic operations, like hashing.
+
+---
+
+#### Storage
+
+```rust
+#[storage]
+struct Storage<Context> {
+    admin: PublicMutable<AztecAddress, Context>, // admin can end vote
+    tally: Map<Field, PublicMutable<Field, Context>, Context>, // we will store candidate as key and number of votes as value
+    vote_ended: PublicMutable<bool, Context>, // vote_ended is boolean
+    active_at_block: PublicImmutable<u32, Context>, // when people can start voting
+}
+```
+-   `#[storage]`: This macro declares the struct that holds all our contract's state variables.
+-   `admin: PublicMutable<AztecAddress, Context>`: Creates a public, changeable state variable named `admin` to store an address. It's like `address public admin;` in Solidity.
+-   `tally: Map<Field, PublicMutable<Field, Context>, Context>`: This is our public vote counter. It's a `mapping` from a candidate's ID (`Field`) to their vote count (`PublicMutable<Field>`). Think `mapping(uint256 => uint256) public tally;` in Solidity.
+-   `vote_ended: PublicMutable<bool, Context>`: A simple public flag to turn voting on or off. Like `bool public voteEnded;` in Solidity.
+-   `active_at_block: PublicImmutable<u32, Context>`: A public, **unchangeable** variable that stores the block number when voting started.
+    -   **Why is this important for security?** In Aztec, users can rotate (change) their secret keys. This variable ensures that a vote is tied to the secret key that was active *at the time voting started*. Without it, a user could vote, rotate their key, and vote again with the new key, creating a different nullifier and breaking the one-vote rule. It's a clever way to anchor the vote's validity to a specific point in time.
+
+---
+
+#### `constructor`
+
+```rust
+#[public]
+#[initializer]
+fn constructor(admin: AztecAddress) {
+    storage.admin.write(admin);
+    storage.vote_ended.write(false);
+    storage.active_at_block.initialize(context.block_number() as u32);
+}
+```
+-   `#[public]`: This function runs on the public part of the network.
+-   `#[initializer]`: Marks this as the constructor, which runs only once when the contract is deployed. Same concept as a `constructor` in Solidity.
+-   `storage.admin.write(admin)`: Sets the `admin` address. `.write()` is used for `PublicMutable` variables.
+-   `storage.active_at_block.initialize(...)`: Sets the immutable `active_at_block` variable. `.initialize()` is used for `PublicImmutable` variables. You can't `.write()` to them after deployment.
+
+---
+
+#### `cast_vote` (The Private Core)
+
+```rust
+#[private]
+fn cast_vote(candidate: Field) {
+    // 1. Get a component of the user's public key
+    let msg_sender_npk_m_hash = get_public_keys(context.msg_sender()).npk_m.hash();
+
+    // 2. Request the corresponding secret key from the local wallet (PXE)
+    let secret = context.request_nsk_app(msg_sender_npk_m_hash);
+
+    // 3. Create the unique, anonymous "used-vote ticket" (nullifier)
+    let nullifier = std::hash::pedersen_hash([context.msg_sender().to_field(), secret]);
+    
+    // 4. Submit the nullifier to the network to be checked and recorded
+    context.push_nullifier(nullifier);
+
+    // 5. Secretly tell the public side to update the tally
+    EasyPrivateVoting::at(context.this_address()).add_to_tally_public(candidate).enqueue(
+        &mut context,
+    );
+}
+```
+-   `#[private]`: This is the magic. This entire function executes **on the user's local machine** inside their PXE. A ZK-proof of its correct execution is generated, and only that proof is sent to the network. The `candidate` you voted for is kept secret from the public chain within this function's context.
+
+-   **Steps 1 & 2: Getting the Secret**
+    -   This is how Aztec creates a secret unique to you *and* this specific contract.
+    -   `get_public_keys(...)` gets a public part of your key set.
+    -   `context.request_nsk_app(...)` is an **Oracle Call**. It's a special request the private circuit makes to the user's wallet (PXE) *during proof generation*. It asks, "Please give me the secret Nullifier Spending Key (NSK) that corresponds to this public key hash." Your wallet provides it securely, and it's used as a private input to the circuit.
+
+-   **Step 3 & 4: The Nullifier**
+    -   `let nullifier = std::hash::pedersen_hash(...)`: We create the nullifier by hashing the user's address with their unique `secret`. Since only the user knows their `secret`, only they can generate this specific nullifier.
+    -   `context.push_nullifier(nullifier)`: This is the crucial step. The transaction tells the Aztec network, "Here is a nullifier. Please check if it's already in the global nullifier tree. If it is, reject this transaction. If not, add it." This is how double-voting is prevented without ever revealing who voted.
+
+-   **Step 5: Private-to-Public Communication**
+    -   A `#[private]` function cannot directly change a `PublicMutable` state variable.
+    -   `.enqueue(&mut context)` is the bridge. It creates a message containing a request to call the `add_to_tally_public` function with the `candidate` as an argument. This message is bundled with the ZK-proof.
+    -   After the network verifies your private proof, it will then execute the enqueued public function call.
+
+---
+
+#### `add_to_tally_public` and `end_vote`
+
+```rust
+#[public]
+#[internal]
+fn add_to_tally_public(candidate: Field) {
+    assert(storage.vote_ended.read() == false, "Vote has ended");
+    let new_tally = storage.tally.at(candidate).read() + 1;
+    storage.tally.at(candidate).write(new_tally);
+}
+
+#[public]
+fn end_vote() {
+    assert(storage.admin.read().eq(context.msg_sender()), "Only admin can end votes");
+    storage.vote_ended.write(true);
+}
+```
+-   These are standard public functions, much like in Solidity.
+-   `#[internal]`: This on `add_to_tally_public` is a security hint. It signifies that this function is *intended* to be called from within the contract itself (via an enqueue from `cast_vote`), not directly by users.
+-   `assert(..., "Error message")`: This is identical to `require(...)` in Solidity. If the condition is false, the transaction reverts with the given error message.
+
+---
+
+#### `get_vote`
+
+```rust
+#[utility]
+unconstrained fn get_vote(candidate: Field) -> Field {
+    storage.tally.at(candidate).read()
+}
+```
+-   `#[utility]` + `unconstrained`: This is a special type of read-only function. It's not part of the ZK circuit and doesn't create a transaction. You can call it from your dApp's frontend/backend to simply read public state from the network without any cost or proof generation. It's the equivalent of a `view` function in Solidity. 

--- a/session_3/1-Private-Voting-Contract/Nargo.toml
+++ b/session_3/1-Private-Voting-Contract/Nargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "private_voting"
+authors = [""]
+compiler_version = ">=0.23.0"
+type = "contract"
+
+[dependencies]
+aztec = { git="https://github.com/AztecProtocol/aztec-packages/", tag="v0.87.4", directory="noir-projects/aztec-nr/aztec" } 

--- a/session_3/1-Private-Voting-Contract/README.md
+++ b/session_3/1-Private-Voting-Contract/README.md
@@ -1,0 +1,142 @@
+# 1. Private Voting Contract Tutorial
+
+This tutorial walks you through creating a simple private voting smart contract in Aztec.nr.
+
+**Goal:** Build a contract where users can vote privately, but the results are tallied publicly. A key feature is using nullifiers to prevent anyone from voting more than once.
+
+## Prerequisites
+
+- You have followed the Aztec quickstart and have `aztec-nargo` and the `aztec` CLI installed.
+- Your Aztec Sandbox is running.
+- We will be using Aztec version `v0.87.4`.
+
+## Step 1: Create a New Contract Project
+
+In your terminal, run the `aztec-nargo` command to create a new contract project.
+
+```bash
+aztec-nargo new --contract private_voting
+```
+
+This will create a new directory `private_voting` with the standard Noir project structure.
+
+## Step 2: Add Aztec Dependencies
+
+Open the `Nargo.toml` file inside your `private_voting` directory. Add the `aztec` library as a dependency. Your file should look like this:
+
+**`Nargo.toml`**
+```toml
+[package]
+name = "private_voting"
+authors = [""]
+compiler_version = ">=0.23.0"
+type = "contract"
+
+[dependencies]
+aztec = { git="https://github.com/AztecProtocol/aztec-packages/", tag="v0.87.4", directory="noir-projects/aztec-nr/aztec" }
+```
+
+## Step 3: Write the Smart Contract
+
+Open the `src/main.nr` file and replace its contents with the full `EasyPrivateVoting` contract code below.
+
+**`src/main.nr`**
+```rust
+use dep::aztec::macros::aztec;
+
+#[aztec]
+pub contract EasyPrivateVoting {
+    // Imports for Aztec functionalities
+    use dep::aztec::{
+        keys::getters::get_public_keys,
+        macros::{functions::{initializer, internal, private, public, utility}, storage::storage},
+    };
+    use dep::aztec::prelude::{AztecAddress, Map, PublicImmutable, PublicMutable};
+    use dep::aztec::protocol_types::traits::{Hash, ToField};
+
+    // Defines the contract's storage variables
+    #[storage]
+    struct Storage<Context> {
+        admin: PublicMutable<AztecAddress, Context>,
+        tally: Map<Field, PublicMutable<Field, Context>, Context>,
+        vote_ended: PublicMutable<bool, Context>,
+        active_at_block: PublicImmutable<u32, Context>,
+    }
+
+    // Constructor: Initializes the contract state on deployment
+    #[public]
+    #[initializer]
+    fn constructor(admin: AztecAddress) {
+        storage.admin.write(admin);
+        storage.vote_ended.write(false);
+        storage.active_at_block.initialize(context.block_number() as u32);
+    }
+
+    // Private function to cast a vote
+    #[private]
+    fn cast_vote(candidate: Field) {
+        // Create a unique nullifier to prevent double-voting
+        let msg_sender_npk_m_hash = get_public_keys(context.msg_sender()).npk_m.hash();
+        let secret = context.request_nsk_app(msg_sender_npk_m_hash);
+        let nullifier = std::hash::pedersen_hash([context.msg_sender().to_field(), secret]);
+        context.push_nullifier(nullifier);
+
+        // Enqueue a call to the public function to update the tally
+        EasyPrivateVoting::at(context.this_address()).add_to_tally_public(candidate).enqueue(
+            &mut context,
+        );
+    }
+
+    // Public function to increment the vote count for a candidate
+    #[public]
+    #[internal]
+    fn add_to_tally_public(candidate: Field) {
+        assert(storage.vote_ended.read() == false, "Vote has ended");
+        let new_tally = storage.tally.at(candidate).read() + 1;
+        storage.tally.at(candidate).write(new_tally);
+    }
+
+    // Public function for the admin to end the voting period
+    #[public]
+    fn end_vote() {
+        assert(storage.admin.read().eq(context.msg_sender()), "Only admin can end votes");
+        storage.vote_ended.write(true);
+    }
+
+    // Utility function to read the vote count for a candidate
+    #[utility]
+    unconstrained fn get_vote(candidate: Field) -> Field {
+        storage.tally.at(candidate).read()
+    }
+}
+```
+
+## Step 4: Compile and Generate Code
+
+Now that the contract is written, compile it to check for errors and create the necessary artifacts for deployment.
+
+Navigate to your `private_voting` directory in the terminal and run:
+
+```bash
+aztec-nargo compile
+```
+
+This will create a `target` directory containing the compiled contract artifact (`.json` file).
+
+Next, generate the TypeScript interface for your contract, which makes it easy to interact with from a dApp.
+
+```bash
+aztec codegen target --outdir src/artifacts
+```
+
+This will create a `src/artifacts` directory containing the generated TypeScript files.
+
+## Summary
+
+Congratulations! You have successfully written, compiled, and generated code for a private voting smart contract on Aztec. You've seen how to:
+- Define public and private state.
+- Use a `constructor` to initialize the contract.
+- Create a `#[private]` function that uses a **nullifier** to enforce a one-vote-per-person rule.
+- Enable private functions to call and update public state via `enqueue`.
+- Implement access control using `assert`.
+- Create a `#[utility]` function to read public state from a dApp. 

--- a/session_3/1-Private-Voting-Contract/src/main.nr
+++ b/session_3/1-Private-Voting-Contract/src/main.nr
@@ -1,0 +1,60 @@
+use dep::aztec::macros::aztec;
+
+#[aztec]
+pub contract EasyPrivateVoting {
+    use dep::aztec::{
+        keys::getters::get_public_keys,
+        macros::{functions::{initializer, internal, private, public, utility}, storage::storage},
+    };
+    use dep::aztec::prelude::{AztecAddress, Map, PublicImmutable, PublicMutable};
+    use dep::aztec::protocol_types::traits::{Hash, ToField};
+
+    #[storage]
+    struct Storage<Context> {
+        admin: PublicMutable<AztecAddress, Context>, // admin can end vote
+        tally: Map<Field, PublicMutable<Field, Context>, Context>, // we will store candidate as key and number of votes as value
+        vote_ended: PublicMutable<bool, Context>, // vote_ended is boolean
+        active_at_block: PublicImmutable<u32, Context>, // when people can start voting
+    }
+
+    #[public]
+    #[initializer]
+    // annotation to mark function as a constructor
+    fn constructor(admin: AztecAddress) {
+        storage.admin.write(admin);
+        storage.vote_ended.write(false);
+        storage.active_at_block.initialize(context.block_number() as u32);
+    }
+
+    #[private]
+    // annotation to mark function as private and expose private context
+    fn cast_vote(candidate: Field) {
+        let msg_sender_npk_m_hash = get_public_keys(context.msg_sender()).npk_m.hash();
+
+        let secret = context.request_nsk_app(msg_sender_npk_m_hash); // get secret key of caller of function
+        let nullifier = std::hash::pedersen_hash([context.msg_sender().to_field(), secret]); // derive nullifier from sender and secret
+        context.push_nullifier(nullifier);
+        EasyPrivateVoting::at(context.this_address()).add_to_tally_public(candidate).enqueue(
+            &mut context,
+        );
+    }
+
+    #[public]
+    #[internal]
+    fn add_to_tally_public(candidate: Field) {
+        assert(storage.vote_ended.read() == false, "Vote has ended"); // assert that vote has not ended
+        let new_tally = storage.tally.at(candidate).read() + 1;
+        storage.tally.at(candidate).write(new_tally);
+    }
+
+    #[public]
+    fn end_vote() {
+        assert(storage.admin.read().eq(context.msg_sender()), "Only admin can end votes"); // assert that caller is admin
+        storage.vote_ended.write(true);
+    }
+
+    #[utility]
+    unconstrained fn get_vote(candidate: Field) -> Field {
+        storage.tally.at(candidate).read()
+    }
+} 

--- a/session_3/2-Account-Abstraction/schnorr_account_contract/EXPLAINED.md
+++ b/session_3/2-Account-Abstraction/schnorr_account_contract/EXPLAINED.md
@@ -1,0 +1,100 @@
+# Deep Dive: The Schnorr Account Contract Explained
+
+This document breaks down the `SchnorrHardcodedAccount` contract. We'll explore how Aztec's native Account Abstraction (AA) empowers developers to redefine the rules of transaction validation.
+
+## The Big Picture: EVM vs. Aztec Accounts
+
+-   **EVM World (Ethereum):** You have two types of accounts.
+    1.  **Externally Owned Account (EOA):** Your regular wallet, controlled by one private key. Simple, but rigid. If you want more features (like multi-sig), you need a separate...
+    2.  **Smart Contract Wallet:** A separate contract (like Gnosis Safe) that holds your assets and has its own logic. To use a dApp, you often send a transaction from your EOA to your Smart Contract Wallet, which then interacts with the dApp. It's a two-step process.
+
+-   **Aztec World (Native AA):** There are no EOAs. **Every account is a smart contract.** This is a fundamental shift. Your "wallet" *is* a programmable contract. This means:
+    -   **Flexible Authentication:** You define what makes a transaction valid. A simple signature? Multiple signatures? A password? A biometric hash? It's all up to the logic you write in your account contract.
+    -   **Seamless Experience:** The user experience is unified. There's no awkward two-step dance between an EOA and a contract wallet.
+
+Our `SchnorrHardcodedAccount` is a perfect example of this. We are swapping out the default signature scheme for another one (Schnorr) to authorize transactions.
+
+---
+
+## Code Breakdown
+
+### `src/main.nr`
+
+#### Imports
+
+```rust
+use dep::authwit::{
+    account::AccountActions,
+    auth_witness::get_auth_witness,
+    entrypoint::{app::AppPayload, fee::FeePayload},
+};
+// ... other imports
+```
+
+-   `dep::authwit::...`: This is the star of the show for Account Abstraction. We are importing key components from the `authwit` (Authentication Witness) library.
+    -   `AccountActions`: Represents the actions (the function calls) a user wants to execute.
+    -   `get_auth_witness`: The special **oracle call** we use to ask the user's wallet for the signature.
+    -   `AppPayload`: A struct that bundles up all the information about the user's desired transaction (who to call, what function, with what arguments).
+
+---
+
+#### `global public_key`
+
+```rust
+global public_key: EmbeddedCurvePoint = EmbeddedCurvePoint {
+    x: 0x16b93f4afa5e5338cb8a65529f5723b71f92b3a99cb9c0f9942352885a49852f,
+    y: 0x011d68a0f5a720973e6cefe68e3d2e81134b22c34795b5c1f6a1e367683451e,
+};
+```
+-   For simplicity, we've hardcoded the public key that is allowed to authorize transactions for this account. In a real-world scenario, you wouldn't hardcode this. You would likely store it in a secure, private, and potentially updatable state variable (`PrivateMutable`) within the contract's storage.
+
+---
+
+#### `entrypoint` (The Gatekeeper)
+
+```rust
+#[private]
+fn entrypoint(payload: AppPayload, fee_payload: FeePayload) -> pub AccountActions {
+    let is_valid = is_valid_impl(payload);
+    assert(is_valid);
+    payload.actions.execute(&mut context)
+}
+```
+-   `entrypoint`: This is a special, mandatory function for all account contracts. **Every single transaction** initiated by this account gets routed through this function first. It is the single point of entry, the gatekeeper that decides if a transaction is allowed to proceed.
+-   `#[private]`: The validation logic happens in the privacy of the user's local PXE.
+-   `payload: AppPayload`: This object contains the list of function calls the user wants to make in their transaction.
+-   `let is_valid = is_valid_impl(payload)`: It first calls our validation logic.
+-   `assert(is_valid)`: If the validation check fails, the entire transaction reverts.
+-   `payload.actions.execute(&mut context)`: If the validation passes, this command tells the Aztec network to proceed with executing the function calls that were bundled in the `payload`.
+
+---
+
+#### `is_valid_impl` (The Validator)
+
+```rust
+fn is_valid_impl(payload: AppPayload) -> bool {
+    // 1. Get the signature
+    let signature: [Field; 64] = get_auth_witness(&mut context, payload.hash());
+    
+    // 2. Verify the signature
+    let verification = std::schnorr::verify_signature(public_key, signature, payload.hash());
+    
+    verification
+}
+```
+
+This is the core logic of our custom account.
+
+-   **Step 1: The Oracle Call**
+    -   `get_auth_witness(&mut context, payload.hash())`: This is the magic. It's an **oracle call** to the user's wallet (PXE).
+    -   **Analogy:** The `entrypoint` function is like a bouncer at a club. The `payload.hash()` is like the bouncer showing you a unique secret phrase for the night. The `get_auth_witness` call is the bouncer saying, "Go ask the person at the door for the secret password that matches this phrase."
+    -   Your wallet (the person at the door) then takes the `payload.hash()` (the secret phrase), signs it with your private key to create a `signature` (the secret password), and hands it back to the bouncer (`entrypoint`).
+    -   This all happens locally and securely. The private key never leaves the wallet. The contract just gets the resulting signature.
+
+-   **Step 2: The Verification**
+    -   `std::schnorr::verify_signature(...)`: The bouncer now has everything they need.
+        1.  The `public_key` (the name on the VIP list, which we hardcoded).
+        2.  The `signature` (the secret password you provided).
+        3.  The `payload.hash()` (the original secret phrase for the night).
+    -   This function checks: "Does the provided secret password (`signature`) correctly match the secret phrase (`payload.hash()`) for the person on the VIP list (`public_key`)?"
+    -   If it matches, it returns `true`. The bouncer lets you in, and your transaction proceeds. Otherwise, it returns `false`, and the `assert` in `entrypoint` kicks you out. 

--- a/session_3/2-Account-Abstraction/schnorr_account_contract/Nargo.toml
+++ b/session_3/2-Account-Abstraction/schnorr_account_contract/Nargo.toml
@@ -1,0 +1,9 @@
+[package]
+name = "schnorr_hardcoded_account"
+authors = [""]
+compiler_version = ">=0.23.0"
+type = "contract"
+
+[dependencies]
+aztec = { git="https://github.com/AztecProtocol/aztec-packages/", tag="v0.87.4", directory="noir-projects/aztec-nr/aztec" }
+authwit = { git="https://github.com/AztecProtocol/aztec-packages/", tag="v0.87.4", directory="noir-projects/aztec-nr/authwit"} 

--- a/session_3/2-Account-Abstraction/schnorr_account_contract/README.md
+++ b/session_3/2-Account-Abstraction/schnorr_account_contract/README.md
@@ -1,0 +1,110 @@
+# 2a. Account Abstraction: The Noir Contract
+
+This tutorial covers the first part of our Account Abstraction deep dive: writing the custom account contract in Noir.
+
+**Goal:** Build a custom account contract that uses a hardcoded Schnorr signature for transaction authentication.
+
+## Background: What is Account Abstraction in Aztec?
+
+In Aztec, every account *is* a smart contract. This is different from Ethereum's EOA model. It means you can define custom logic for how your account authorizes transactions. Instead of being limited to a single private key signature (like an EOA), you can implement multi-sig, social recovery, or, as we'll do here, use a different signature scheme like Schnorr.
+
+## Step 1: Create a New Contract Project
+
+If you haven't already, create a new directory for this project.
+
+```bash
+# In your session_3/2-Account-Abstraction/ directory
+aztec-nargo new --contract schnorr_account_contract
+```
+
+This creates the `schnorr_account_contract` directory with the standard `src` and `Nargo.toml` files.
+
+## Step 2: Add Dependencies
+
+Open `schnorr_account_contract/Nargo.toml` and add the `aztec` and `authwit` libraries as dependencies. The `authwit` library is crucial as it provides the necessary tools and interfaces for building custom account authentication logic.
+
+**`Nargo.toml`**
+```toml
+[package]
+name = "schnorr_hardcoded_account"
+authors = [""]
+compiler_version = ">=0.23.0"
+type = "contract"
+
+[dependencies]
+aztec = { git="https://github.com/AztecProtocol/aztec-packages/", tag="v0.87.4", directory="noir-projects/aztec-nr/aztec" }
+authwit = { git="https://github.com/AztecProtocol/aztec-packages/", tag="v0.87.4", directory="noir-projects/aztec-nr/authwit"}
+```
+
+## Step 3: Write the Account Contract
+
+Open `schnorr_account_contract/src/main.nr` and replace its contents with the code below. This contract defines the rules for our custom account.
+
+**`src/main.nr`**
+```rust
+// Account contract that uses Schnorr signatures for authentication using a hardcoded public key.
+use dep::aztec::macros::aztec;
+
+#[aztec]
+pub contract SchnorrHardcodedAccount {
+    use dep::authwit::{
+        account::AccountActions,
+        auth_witness::get_auth_witness,
+        entrypoint::{app::AppPayload, fee::FeePayload},
+    };
+    use dep::aztec::prelude::PrivateContext;
+    use dep::aztec::macros::functions::{private, view};
+    use std::embedded_curve_ops::EmbeddedCurvePoint;
+
+    // Hardcoded public key for Schnorr verification
+    global public_key: EmbeddedCurvePoint = EmbeddedCurvePoint {
+        x: 0x16b93f4afa5e5338cb8a65529f5723b71f92b3a99cb9c0f9942352885a49852f,
+        y: 0x011d68a0f5a720973e6cefe68e3d2e81134b22c34795b5c1f6a1e367683451e,
+    };
+
+    // The main entrypoint for all transactions for this account
+    #[private]
+    fn entrypoint(payload: AppPayload, fee_payload: FeePayload) -> pub AccountActions {
+        let is_valid = is_valid_impl(payload);
+        assert(is_valid);
+        payload.actions.execute(&mut context)
+    }
+
+    // A view function to check validity without sending a transaction
+    #[view]
+    fn is_valid(payload: AppPayload) -> bool {
+        is_valid_impl(payload)
+    }
+
+    // The core validation logic
+    fn is_valid_impl(payload: AppPayload) -> bool {
+        // 1. Request the signature (auth witness) from the user's wallet (PXE)
+        let signature: [Field; 64] = get_auth_witness(&mut context, payload.hash());
+        
+        // 2. Verify the signature against the hardcoded public key
+        let verification = std::schnorr::verify_signature(public_key, signature, payload.hash());
+        
+        verification
+    }
+}
+```
+
+## Step 4: Compile the Contract
+
+Navigate to your `schnorr_account_contract` directory and run the compile command:
+
+```bash
+aztec-nargo compile
+```
+
+If successful, this verifies your code is correct and creates the compiled artifact in the `target/` directory.
+
+## Summary
+
+You have now created the core Noir logic for a custom Aztec account. The key takeaways are:
+-   Every Aztec account is a contract, giving you full control over its logic.
+-   The `entrypoint` function is the gatekeeper for all transactions.
+-   The `authwit` library and `get_auth_witness` oracle call are how your contract securely requests authentication data (like a signature) from the user's wallet during a transaction.
+-   You can use any cryptographic scheme you can implement in Noir to validate transactions.
+
+In the next section, we'll write the TypeScript "glue code" needed to deploy this contract and use it as a real account from a Node.js application. 

--- a/session_3/2-Account-Abstraction/schnorr_account_contract/src/main.nr
+++ b/session_3/2-Account-Abstraction/schnorr_account_contract/src/main.nr
@@ -1,0 +1,39 @@
+// Account contract that uses Schnorr signatures for authentication using a hardcoded public key.
+use dep::aztec::macros::aztec;
+
+#[aztec]
+pub contract SchnorrHardcodedAccount {
+    use dep::authwit::{
+        account::AccountActions,
+        auth_witness::get_auth_witness,
+        entrypoint::{app::AppPayload, fee::FeePayload},
+    };
+    use dep::aztec::prelude::PrivateContext;
+
+    use dep::aztec::macros::functions::{private, view};
+    use std::embedded_curve_ops::EmbeddedCurvePoint;
+
+    // Hardcoded public key for Schnorr verification
+    global public_key: EmbeddedCurvePoint = EmbeddedCurvePoint {
+        x: 0x16b93f4afa5e5338cb8a65529f5723b71f92b3a99cb9c0f9942352885a49852f,
+        y: 0x011d68a0f5a720973e6cefe68e3d2e81134b22c34795b5c1f6a1e367683451e,
+    };
+
+    #[private]
+    fn entrypoint(payload: AppPayload, fee_payload: FeePayload) -> pub AccountActions {
+        let is_valid = is_valid_impl(payload);
+        assert(is_valid);
+        payload.actions.execute(&mut context)
+    }
+
+    #[view]
+    fn is_valid(payload: AppPayload) -> bool {
+        is_valid_impl(payload)
+    }
+
+    fn is_valid_impl(payload: AppPayload) -> bool {
+        let signature: [Field; 64] = get_auth_witness(&mut context, payload.hash());
+        let verification = std::schnorr::verify_signature(public_key, signature, payload.hash());
+        verification
+    }
+} 

--- a/session_3/2-Account-Abstraction/typescript_interaction/EXPLAINED.md
+++ b/session_3/2-Account-Abstraction/typescript_interaction/EXPLAINED.md
@@ -1,0 +1,101 @@
+# Deep Dive: The Account Abstraction TypeScript Explained
+
+This document breaks down the `index.ts` script, revealing how `aztec.js` acts as the bridge between your dApp and your custom account contract on the Aztec network.
+
+## The Big Picture: From Code to Account
+
+Our goal is to stop using the default, pre-deployed Aztec accounts and start using our very own `SchnorrHardcodedAccount`. The process looks like this:
+
+1.  **Generate Keys:** We need a new private key that will control our account.
+2.  **Get the Blueprint:** We load the compiled artifact of our `SchnorrHardcodedAccount` contract. This is the blueprint that tells `aztec.js` what the contract looks like.
+3.  **Deploy the Account:** We send a special transaction to deploy our account contract blueprint to the network. The network gives us back a new, unique address for our account.
+4.  **Create a "Wallet":** We create a `wallet` object in TypeScript. This object is more than just keys; it's a smart interface that holds our private key and knows that it needs to follow the rules of our `SchnorrHardcodedAccount` contract when signing transactions.
+5.  **Use the Wallet:** From now on, whenever we want to send a transaction (like deploying a new Token contract or calling one of its functions), we pass this special `wallet` object. `aztec.js` sees this and says, "Ah, this isn't a standard account. I need to ask its `entrypoint` function for permission first." It then works with the wallet to generate the required Schnorr signature to satisfy the `entrypoint`'s `assert` check.
+
+---
+
+## Code Breakdown
+
+### `src/index.ts`
+
+#### Imports
+
+```typescript
+import {
+  AccountManager,
+  AccountWallet,
+  // ...
+  GrumpkinScalar,
+  PXE,
+  createPXEClient,
+  // ...
+} from "@aztec/aztec.js";
+import { AuthWitnessProvider, SchnorrAccountContract } from "@aztec/accounts/schnorr";
+import { TokenContract } from "@aztec/noir-contracts.js/Token";
+```
+
+-   `@aztec/aztec.js`: The core library. We import `createPXEClient` to connect to the sandbox, `AccountManager` to help deploy our account, and `GrumpkinScalar` to represent our private key.
+-   `@aztec/accounts/schnorr`: This is a helper library provided by Aztec that contains ready-made pieces for Schnorr-based accounts.
+    -   `SchnorrAccountContract`: A convenient class that already has the `SchnorrHardcodedAccount` artifact loaded.
+    -   `AuthWitnessProvider`: This is the client-side component responsible for *creating* the authentication witness (the signature). When the contract's `entrypoint` calls `get_auth_witness` (the oracle call), this provider is what answers the call, creates the Schnorr signature with the private key, and passes it back to the contract.
+-   `@aztec/noir-contracts.js/Token`: A pre-compiled version of a standard Token contract, which we use as an example to interact with.
+
+---
+
+#### The `main` Function
+
+```typescript
+// 1. Connect to the Aztec Sandbox (PXE)
+const pxe = createPXEClient(PXE_URL, { fetch: mustSucceedFetch });
+await waitForPXE(pxe, logger);
+```
+- Standard connection setup. We establish a connection to our local Private Execution Environment (PXE).
+
+```typescript
+// 2. Load our custom account contract artifact
+const accountContractArtifact = new SchnorrAccountContract().artifact;
+```
+- Here we load the compiled JSON blueprint of our account contract.
+
+```typescript
+// 3. Create a new key set for our custom account
+const privateKey = GrumpkinScalar.random();
+const publicKey = generatePublicKey(privateKey);
+```
+- We generate a fresh `privateKey` using `GrumpkinScalar.random()`. This key will be the "owner" of our new account contract and will be used to generate the Schnorr signatures.
+
+```typescript
+// 4. Create an AccountManager to handle the deployment
+const accountManager = new AccountManager(pxe, privateKey, accountContractArtifact);
+```
+- The `AccountManager` is a powerful helper class in `aztec.js`. You give it three things:
+    1.  A connection to the `pxe`.
+    2.  The `privateKey` that will control the account.
+    3.  The `accountContractArtifact` (the blueprint) of the account you want to deploy.
+- It simplifies the process of deploying a new account contract and registering it with the PXE.
+
+```typescript
+// 5. Deploy the custom account contract
+const wallet = await accountManager.deploy(publicKey).wait();
+```
+-   `accountManager.deploy(publicKey)`: This is the action step. The manager constructs and sends the deployment transaction for our account contract.
+-   `.wait()`: We wait for the deployment transaction to be mined.
+-   `const wallet`: The `deploy` method returns a `wallet` object. This is our specialized wallet instance, ready to be used. It's an `AccountWallet` that has been configured internally with our `privateKey` and an `AuthWitnessProvider` that knows how to create Schnorr signatures.
+
+```typescript
+// 6. Use the new account to deploy a Token contract
+const tokenContract = await TokenContract.deploy(
+    wallet, // Use our custom wallet!
+    // ...
+).send().deployed();
+```
+- This is the payoff! We call `TokenContract.deploy` as usual, but in the first argument, where we specify *who* is deploying, we pass our custom `wallet`.
+- **What happens under the hood?** `aztec.js` sees this isn't a standard wallet. It constructs the `AppPayload` for the token deployment, but before sending, it invokes the `entrypoint` of our `SchnorrHardcodedAccount`. The `entrypoint` asks for an `authwit`, so the `AuthWitnessProvider` inside our `wallet` generates the required Schnorr signature, which is passed into the `entrypoint`'s proof. The `assert` passes, and the token deployment proceeds.
+
+```typescript
+// 7. Interact with the Token contract using the custom account
+await tokenContract.methods.mint_to_private(...).send().wait();
+```
+- The exact same logic applies here. When we call `mint_to_private`, the `tokenContract` instance (which was created using our custom `wallet`) knows it must first get approval from our `SchnorrHardcodedAccount`'s `entrypoint`. The authentication flow happens automatically, and the minting transaction is executed.
+
+This completes the cycle, proving that our custom on-chain authentication logic is now seamlessly integrated into our client-side dApp development flow. 

--- a/session_3/2-Account-Abstraction/typescript_interaction/README.md
+++ b/session_3/2-Account-Abstraction/typescript_interaction/README.md
@@ -1,0 +1,126 @@
+# 2b. Account Abstraction: The TypeScript Interaction
+
+This tutorial covers the second part of our Account Abstraction deep dive: writing the TypeScript "glue code" to deploy and interact with our custom `SchnorrHardcodedAccount` contract.
+
+**Goal:** Use Aztec.js to deploy our custom account contract and then use that new account to deploy and interact with a `Token` contract.
+
+## Prerequisites
+- You have completed Part 2a and have the compiled `schnorr_account_contract` artifact.
+- You have a running Aztec Sandbox.
+- You have Node.js and Yarn (or npm) installed.
+
+## Step 1: Project Setup
+
+Create a new directory for your TypeScript project (`typescript_interaction`) and set up your `package.json` and `tsconfig.json` as detailed in the previous steps.
+
+Install the necessary dependencies:
+
+```bash
+yarn add @aztec/aztec.js@0.87.4 @aztec/accounts@0.87.4 @aztec/noir-contracts.js@0.87.4 typescript @types/node
+```
+
+## Step 2: The Interaction Script
+
+Create a file named `src/index.ts`. This script will perform all the actions. Below is the complete code, which we'll break down in the `EXPLAINED.md` file.
+
+**`src/index.ts`**
+```typescript
+import {
+  AccountManager,
+  AccountWallet,
+  AztecAddress,
+  CompleteAddress,
+  Fr,
+  GrumpkinScalar,
+  PXE,
+  createPXEClient,
+  waitForPXE,
+  generatePublicKey,
+  mustSucceedFetch,
+} from "@aztec/aztec.js";
+import { AuthWitnessProvider, SchnorrAccountContract } from "@aztec/accounts/schnorr";
+import { TokenContract } from "@aztec/noir-contracts.js/Token";
+import { createLogger } from "@aztec/foundation/log";
+import { format } from "util";
+
+// --- CONFIG ---
+const { PXE_URL = "http://localhost:8080" } = process.env;
+const logger = createLogger("aztec:http-pxe-client");
+// --- END CONFIG ---
+
+async function main() {
+  // 1. Connect to the Aztec Sandbox (PXE)
+  const pxe = createPXEClient(PXE_URL, { fetch: mustSucceedFetch });
+  await waitForPXE(pxe, logger);
+  logger.info("Connected to PXE.");
+
+  // 2. Load our custom account contract artifact
+  // NOTE: This assumes you have compiled the Noir contract from Part 2a
+  const accountContractArtifact = new SchnorrAccountContract().artifact;
+
+  // 3. Create a new key set for our custom account
+  const privateKey = GrumpkinScalar.random();
+  const publicKey = generatePublicKey(privateKey);
+
+  // 4. Create an AccountManager to handle the deployment
+  const accountManager = new AccountManager(pxe, privateKey, accountContractArtifact);
+
+  // 5. Deploy the custom account contract
+  logger.info("Deploying custom account contract...");
+  const wallet = await accountManager.deploy(publicKey).wait();
+  logger.info(`Custom account deployed at: ${wallet.getAddress().toString()}`);
+
+  // 6. Use the new account to deploy a Token contract
+  logger.info("Deploying Token contract with custom account...");
+  const tokenContract = await TokenContract.deploy(
+    wallet, // Use our custom wallet!
+    wallet.getAddress(),
+    "TestToken",
+    "TKN",
+    18
+  ).send().deployed();
+  logger.info(`Token contract deployed at: ${tokenContract.address.toString()}`);
+
+  // 7. Interact with the Token contract using the custom account
+  const mintAmount = 100n;
+  logger.info(`Minting ${mintAmount} tokens...`);
+  await tokenContract.methods.mint_to_private(wallet.getAddress(), wallet.getAddress(), mintAmount).send().wait();
+
+  const balance = await tokenContract.methods.balance_of_private(wallet.getAddress()).simulate();
+  logger.info(`Private balance of custom account: ${balance}`);
+  
+  if (balance !== mintAmount) throw new Error("Incorrect balance!");
+
+  logger.info("✅ Successfully used a custom account to deploy and interact with a contract!");
+}
+
+main().catch((err) => {
+  logger.error(err);
+  process.exit(1);
+});
+```
+
+## Step 3: Run the Script
+
+First, build the TypeScript code:
+```bash
+yarn build
+```
+
+Then, run the compiled JavaScript:
+```bash
+node dest/index.js
+```
+
+## Summary
+
+If the script runs successfully, you have just:
+1.  Connected to the Aztec network.
+2.  Generated a new private key for a custom account.
+3.  Deployed the `SchnorrHardcodedAccount` contract to the network.
+4.  Created a `wallet` instance that knows how to sign transactions for this custom account.
+5.  **Used your custom account** to deploy a completely separate `Token` contract.
+6.  **Used your custom account again** to call the `mint_to_private` function on the `Token` contract.
+7.  Queried the result to confirm the interaction was successful.
+
+This demonstrates the end-to-end power of Account Abstraction in Aztec. You are no longer just a user; you are the architect of your own account's security model. 

--- a/session_3/2-Account-Abstraction/typescript_interaction/package.json
+++ b/session_3/2-Account-Abstraction/typescript_interaction/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "aa-typescript-interaction",
+  "version": "1.0.0",
+  "type": "module",
+  "scripts": {
+    "build": "yarn clean && tsc -b",
+    "build:dev": "tsc -b --watch",
+    "clean": "rm -rf ./dest tsconfig.tsbuildinfo",
+    "start": "yarn build && node ./dest/index.js"
+  },
+  "dependencies": {
+    "@aztec/aztec.js": "0.87.4",
+    "@aztec/accounts": "0.87.4",
+    "@aztec/noir-contracts.js": "0.87.4",
+    "typescript": "^5.2.2",
+    "@types/node": "^20.8.2"
+  },
+  "devDependencies": {
+    "ts-node": "^10.9.1"
+  }
+} 

--- a/session_3/2-Account-Abstraction/typescript_interaction/src/index.ts
+++ b/session_3/2-Account-Abstraction/typescript_interaction/src/index.ts
@@ -1,0 +1,96 @@
+import {
+  AccountManager,
+  AccountWallet,
+  AztecAddress,
+  CompleteAddress,
+  Fr,
+  GrumpkinScalar,
+  PXE,
+  createPXEClient,
+  waitForPXE,
+  generatePublicKey,
+  mustSucceedFetch,
+} from "@aztec/aztec.js";
+import { AuthWitnessProvider, SchnorrAccountContract } from "@aztec/accounts/schnorr";
+import { TokenContract } from "@aztec/noir-contracts.js/Token";
+import { getDeployedTestAccountsWallets } from "@aztec/accounts/testing";
+import { createLogger } from "@aztec/foundation/log";
+import { format } from "util";
+import path from "path";
+import { fileURLToPath } from "url";
+
+// --- CONFIG ---
+const { PXE_URL = "http://localhost:8080" } = process.env;
+const logger = createLogger("aztec:http-pxe-client");
+// --- END CONFIG ---
+
+/**
+ * A class that provides a wallet interface for a custom Schnorr account contract.
+ * It's main purpose is to override the `createAuthWit` method to provide a custom signature.
+ */
+class SchnorrHardcodedAccountWallet extends AccountWallet {
+  constructor(pxe: PXE, address: CompleteAddress, privateKey: GrumpkinScalar) {
+    super(pxe, address, new AuthWitnessProvider(privateKey));
+  }
+}
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+async function main() {
+  // --- 1. Connect to PXE and get accounts ---
+  const pxe = createPXEClient(PXE_URL, { fetch: mustSucceedFetch });
+  await waitForPXE(pxe, logger);
+  const nodeInfo = await pxe.getNodeInfo();
+  logger.info(format("Aztec Sandbox Info:", nodeInfo));
+
+  // --- 2. Compile and Deploy the Custom Account Contract ---
+  logger.info("Compiling account contract...");
+
+  // We are assuming that the schnorr_account_contract was compiled using the command
+  // `aztec-nargo compile` in the `schnorr_account_contract` directory
+  const accountContractArtifact = new SchnorrAccountContract().artifact;
+
+  // --- 3. Create the Account Manager and Wallet ---
+  const privateKey = GrumpkinScalar.random();
+  const publicKey = generatePublicKey(privateKey);
+
+  const accountManager = new AccountManager(pxe, privateKey, accountContractArtifact);
+
+  logger.info("Deploying custom account contract...");
+  const wallet = await accountManager.deploy(publicKey).wait();
+  logger.info(`Custom account deployed at: ${wallet.getAddress().toString()}`);
+
+  // --- 4. Use the Custom Account to Deploy and Interact with a Token Contract ---
+  logger.info("Deploying Token contract with custom account...");
+
+  const tokenContract = await TokenContract.deploy(
+    wallet, // The custom account wallet
+    wallet.getAddress(),
+    "TestToken",
+    "TKN",
+    18
+  ).send().deployed();
+
+  logger.info(`Token contract deployed at: ${tokenContract.address.toString()}`);
+
+  // Now, let's use the custom account to mint tokens
+  const mintAmount = 100n;
+  logger.info(`Minting ${mintAmount} tokens to own account...`);
+  
+  await tokenContract.methods.mint_to_private(wallet.getAddress(), wallet.getAddress(), mintAmount).send().wait();
+
+  const balance = await tokenContract.methods.balance_of_private(wallet.getAddress()).simulate();
+  logger.info(`Private balance of custom account: ${balance}`);
+
+  if (balance !== mintAmount) {
+    throw new Error(`Expected balance of ${mintAmount} but got ${balance}`);
+  }
+
+  logger.info("Successfully used custom account to deploy and interact with a contract!");
+}
+
+main().catch((err) => {
+  logger.error("Error in main function: ", err);
+  process.exit(1);
+}); 

--- a/session_3/2-Account-Abstraction/typescript_interaction/tsconfig.json
+++ b/session_3/2-Account-Abstraction/typescript_interaction/tsconfig.json
@@ -1,0 +1,23 @@
+{
+  "compilerOptions": {
+    "outDir": "dest",
+    "rootDir": "src",
+    "target": "es2020",
+    "lib": ["dom", "esnext", "es2017.object"],
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "strict": true,
+    "declaration": true,
+    "allowSyntheticDefaultImports": true,
+    "esModuleInterop": true,
+    "downlevelIteration": true,
+    "inlineSourceMap": true,
+    "declarationMap": true,
+    "importHelpers": true,
+    "resolveJsonModule": true,
+    "composite": true,
+    "skipLibCheck": true
+  },
+  "references": [],
+  "include": ["src", "src/*.json"]
+} 

--- a/session_3/3-Key-Concepts-Deep-Dive/Account_Abstraction_vs_EVM.md
+++ b/session_3/3-Key-Concepts-Deep-Dive/Account_Abstraction_vs_EVM.md
@@ -1,0 +1,46 @@
+# Key Concept: Account Abstraction (Aztec vs. EVM)
+
+"Account Abstraction" (AA) is a term that means "making accounts more flexible and programmable." Both Ethereum and Aztec have a form of AA, but they are architecturally very different. Understanding this difference is key to grasping the power of Aztec.
+
+## The EVM Model: EOAs + Smart Contract Wallets
+
+In the Ethereum Virtual Machine (EVM), there are two distinct types of "accounts":
+
+1.  **Externally Owned Accounts (EOAs):**
+    -   This is your standard wallet (like MetaMask).
+    -   It's a simple public/private key pair.
+    -   It is controlled *externally* by a person holding the private key.
+    -   **Limitation:** The logic is fixed. It can only sign and send transactions. It cannot have custom logic like spending limits, multi-signature requirements, or social recovery baked into it.
+
+2.  **Smart Contract Accounts (or "Smart Wallets"):**
+    -   These are smart contracts that are designed to hold assets and execute actions on behalf of a user (e.g., Gnosis Safe, Argent).
+    -   They can have any logic you can code in Solidity: multi-sig, daily limits, white-listed addresses, etc.
+    -   **Limitation:** It's not a "native" account. To use it, an EOA must pay gas and send a transaction *to* the smart contract wallet, which then executes the desired action. This often results in a clunky, two-step user experience and higher gas costs.
+
+**Analogy: A Person with a Bank Account**
+- An **EOA** is like you, a person. You can sign checks with your signature, but that's it.
+- A **Smart Contract Wallet** is like a trust or a company you set up. You (the person) have to give instructions to the trust (the contract), and the trust then acts on your behalf according to its own complex rules.
+
+ERC-4337 is a major effort to reduce this friction on Ethereum, but it still works within this fundamental EOA/Contract Account separation.
+
+## The Aztec Model: Native Account Abstraction
+
+In Aztec, this separation does not exist.
+
+**Every single account on the Aztec network *is* a smart contract.**
+
+There are no EOAs in the EVM sense. When you create a "wallet" in Aztec, you are deploying a smart contract that will represent your identity and hold your assets.
+
+This means:
+
+-   **Programmable Validity:** The logic for what makes a transaction valid is defined directly in the account contract itself. The default account uses a standard signature scheme, but as we saw in our tutorial, you can easily replace it with Schnorr signatures, multi-sig logic, or anything else you can write in Noir.
+-   **The `entrypoint` Function:** This function is the heart of Aztec AA. It is a mandatory function in every account contract that acts as the single gatekeeper for all transactions originating from that account. Before any transaction proceeds, it must first pass the logic defined in its account's `entrypoint`.
+-   **Unified & Seamless UX:** There is no two-step process. When a user interacts with a dApp, their `wallet` object (which represents their account contract) seamlessly handles the custom authentication flow in the background. To the user and the dApp, it feels like a single, direct interaction.
+
+**Analogy: A Programmable Robot**
+- An **Aztec Account** is like a programmable robot that holds your assets. You define its operating system.
+- By default, it might only respond to your password (`DefaultAccount`).
+- But you can reprogram it to require two passwords, or a password and a fingerprint, or only operate between 9 AM and 5 PM.
+- When you want to do something, you give a command to the robot. The robot checks its internal rules (`entrypoint` function) to see if your command is valid before executing it.
+
+This native implementation of Account Abstraction is a fundamental advantage of Aztec, providing developers with unparalleled flexibility and security while creating a simpler and more powerful experience for users. 

--- a/session_3/3-Key-Concepts-Deep-Dive/Authwit.md
+++ b/session_3/3-Key-Concepts-Deep-Dive/Authwit.md
@@ -1,0 +1,39 @@
+# Key Concept: Authwit (Authentication Witness)
+
+`Authwit`, or **Authentication Witness**, is a core concept in Aztec that enables advanced Account Abstraction and sophisticated interactions between contracts. It's a generalized way for an account to grant another contract (or user) permission to perform an action on its behalf.
+
+**Analogy: A Notarized Permission Slip**
+
+Imagine you want to allow your friend to withdraw a specific amount of money from your bank account, but only for a specific purpose (e.g., to pay for a specific bill).
+
+-   **The Old Way (`approve`/`allowance` in EVM):** You tell the bank, "My friend is allowed to withdraw up to $100 from my account." This is a blanket approval. Your friend could withdraw $100 for any reason, and the bank wouldn't know the difference.
+-   **The `Authwit` Way:** You write a detailed, signed, and notarized permission slip. It says: *"I, [Your Name], authorize [Friend's Name] to call the `payBill` function at [Electric Company's Address] with the exact arguments: `(bill_id: 123, amount: $50)`. This permission slip is valid only for this specific action."*
+
+An `Authwit` is like this hyper-specific, notarized permission slip.
+
+## What is an `Authwit`?
+
+An Authentication Witness is a **signed message** that authorizes a specific action. The "action" is a hash of all the critical details of a function call:
+-   **`caller`**: Who is being granted permission? (e.g., a DeFi contract's address)
+-   **`contract`**: Which contract are they allowed to call? (e.g., a Token contract's address)
+-   **`selector`**: Which specific function are they allowed to call? (e.g., the `transfer` function)
+-   **`argsHash`**: A hash of the *exact* arguments they are allowed to use. (e.g., `hash(from: my_address, to: defi_address, amount: 100)`)
+
+The hash of all these components creates a unique "action hash": `H(caller, contract, selector, argsHash)`.
+
+Your account then signs this action hash, creating a signature, or "witness."
+
+## How is it Used?
+
+In our `SchnorrHardcodedAccount` contract, the entire transaction payload was the "action":
+
+1.  **Client-Side:** Our `aztec.js` script built a transaction (e.g., `TokenContract.deploy(...)`). This set of actions was hashed to create a `payload.hash()`.
+2.  **Oracle Call:** Inside the account's `entrypoint`, the `get_auth_witness(&mut context, payload.hash())` oracle call asked the wallet, "Please give me the signature (the witness) for this specific `payload.hash()`."
+3.  **Signature Provided:** The `AuthWitnessProvider` in our TypeScript `wallet` object signed the hash using our private key and provided the signature back to the contract.
+4.  **Verification:** The contract then verified that the provided signature was valid for the given `payload.hash()` and the account's public key.
+
+This pattern is incredibly powerful. It allows for things like:
+- **Gasless Swaps:** A relayer pays your gas, but they can only submit a transaction with the exact `swap` action you've pre-authorized with an `Authwit`. They can't change the parameters to steal your funds.
+- **Session Keys:** You can grant a temporary key permission to perform only specific actions (e.g., make moves in a game) for a limited time, without giving it full control over your account.
+
+`Authwit` separates the **authorization** of an action from its **execution**, providing a flexible and secure foundation for complex dApp interactions in Aztec. 

--- a/session_3/3-Key-Concepts-Deep-Dive/Nullifiers.md
+++ b/session_3/3-Key-Concepts-Deep-Dive/Nullifiers.md
@@ -1,0 +1,39 @@
+# Key Concept: Nullifiers
+
+Nullifiers are one of the most ingenious "magic tricks" in a private blockchain like Aztec. They are the core mechanism that prevents double-spending of private assets without revealing which asset is being spent.
+
+**The Problem:** In a private system, your assets are represented by secret encrypted "notes" (think of them like individual, unspent bills in your wallet). When you want to spend a note, you need to prove to the network that you own it and that it's valid. However, since the network can't see your private information, how does it know you haven't already spent that same note in a previous transaction?
+
+**The Solution: A Public Board of "Used Tickets"**
+
+A nullifier is a unique, one-time-use serial number that is publicly revealed when you spend a private note.
+
+**Analogy: The Concert Ticket Stub**
+
+Imagine you have a private concert ticket with a unique serial number that only you can see.
+1.  **Spending the Note:** When you go to the concert, you show your private ticket to the bouncer (`#[private]` function execution). The bouncer doesn't care about your name, only that the ticket is valid.
+2.  **Generating the Nullifier:** The bouncer tears your ticket in half. They keep the main part (the note is consumed) and hand you back the **stub** (the nullifier). This stub has the same unique serial number on it.
+3.  **Revealing the Nullifier:** You walk past the bouncer and drop the ticket stub into a large, clear, public glass bowl (the **Nullifier Tree** on the Aztec network).
+4.  **Preventing Double-Spending:** Now, imagine you try to enter the concert again with a photocopy of your original ticket. The bouncer (the Aztec network protocol) will first check the public glass bowl. They will see a stub with your serial number already in it and will deny you entry, rejecting the transaction.
+
+Crucially, nobody looking at the glass bowl of stubs can tell who dropped which stub in. They just see a list of used serial numbers.
+
+## How are Nullifiers Created?
+
+A nullifier is created by hashing a user's secret information with information about the asset they are spending. A simplified model looks like this:
+
+`nullifier = hash(user_secret_key, note_commitment)`
+
+-   **`user_secret_key`**: A secret key known only to the user. In our voting contract, this was the `secret` we requested from the PXE via the `request_nsk_app` oracle call.
+-   **`note_commitment`**: A public "pointer" to the specific note being spent.
+
+Because the user's secret key is part of the hash, only the true owner of a note can generate its correct nullifier. And because the nullifier is deterministic, spending the same note will always produce the exact same nullifier.
+
+## The `context.push_nullifier(nullifier)` command
+
+This is the line in our `cast_vote` function where the magic happens. When a private function includes this command, it instructs the Aztec network:
+1.  First, check if this `nullifier` value already exists in the public Nullifier Tree.
+2.  If it does, **fail the entire transaction immediately.**
+3.  If it does not, accept this transaction and **add the `nullifier` to the tree** so it cannot be used again.
+
+This simple, powerful mechanism is what gives Aztec private state the same double-spend protection as the public state of other blockchains. 

--- a/session_3/3-Key-Concepts-Deep-Dive/Oracles.md
+++ b/session_3/3-Key-Concepts-Deep-Dive/Oracles.md
@@ -1,0 +1,35 @@
+# Key Concept: Oracles (in Aztec)
+
+In the broader blockchain world, an "oracle" is typically a service that brings external, real-world data (like the price of BTC/USD) onto the public blockchain. In Aztec, the term **Oracle Call** refers to something more specific and fundamental to how private execution works: it's a mechanism for a private function, during proof generation, to request information from the user's local Private Execution Environment (PXE).
+
+**Analogy: Consulting Your Notes During an Exam**
+
+Imagine you are taking a very difficult, closed-book exam (`#[private]` function execution). The exam room is isolated and secure (the ZK-proof environment). However, the exam proctor (the Aztec protocol) allows you a special privilege: at certain points, you can raise your hand and ask your personal tutor (the **PXE**), who is waiting right outside the door, for a specific piece of information from your private notebook.
+
+-   You can't ask for the final answer.
+-   You can only ask for specific data points you need to solve the problem.
+-   The proctor doesn't see the information on your notes; they only see you asking the question and receiving an answer. The information goes directly into your exam paper (the witness for the ZK-proof).
+
+This is exactly what an oracle call is in Aztec. It's a secure communication channel between a private circuit being proved and the user's wallet, which holds all the secret information.
+
+## How Do Oracle Calls Work?
+
+When the Noir compiler encounters an oracle call function inside a `#[private]` function, it embeds a special instruction into the circuit. When the PXE executes this circuit to generate a proof, it sees this instruction and pauses the execution. It then provides the requested information, and the circuit execution resumes with this new information included as a private input.
+
+## Examples from Our Tutorials
+
+We have already seen two major examples of oracle calls:
+
+1.  **`context.request_nsk_app(...)`** (from the Private Voting contract)
+    -   **The Question:** "Hey PXE, I need the secret Nullifier Spending Key (NSK) that is associated with this application and this user. I need it to generate a unique nullifier so this user can't vote twice."
+    -   **The Answer:** The PXE provides the secret key, which is used inside the `cast_vote` function to create the nullifier.
+
+2.  **`get_auth_witness(&mut context, payload.hash())`** (from the Account Abstraction contract)
+    -   **The Question:** "Hey PXE, I need an authentication witness. Please take this transaction payload hash, sign it with the user's authentication private key, and give me the resulting signature."
+    -   **The Answer:** The PXE (via the `AuthWitnessProvider`) provides the Schnorr signature, which is then used inside the `is_valid_impl` function to verify the transaction's authenticity.
+
+Another common example is fetching private notes: when you want to make a transfer, an oracle call is used to ask the PXE, "Which of my private notes can I use to cover this amount?" The PXE provides the necessary notes to be consumed in the transaction.
+
+## Why are Oracles Necessary for Privacy?
+
+Oracles are the bridge that makes private dApps practical. Private functions need access to secrets to do their work—secrets that cannot be passed in as public function arguments or stored in public state. Oracle calls provide a secure and standardized way for a circuit to say, "I have reached a point where I need secret information X," allowing the user's own machine to privately inject that secret into the proof, keeping it shielded from the public network. 

--- a/session_3/3-Key-Concepts-Deep-Dive/PXE.md
+++ b/session_3/3-Key-Concepts-Deep-Dive/PXE.md
@@ -1,0 +1,31 @@
+# Key Concept: The PXE (Private Execution Environment)
+
+The Private Execution Environment, or PXE (pronounced "pixie"), is one of the most critical components of the Aztec architecture. It's a piece of software that runs on the user's local machine (or in their browser) and acts as their personal, trusted gateway to the Aztec network.
+
+**Analogy: Your Personal Assistant for Privacy**
+
+Think of the PXE as a highly skilled, trustworthy personal assistant who handles all your sensitive financial information.
+- You don't shout your bank account password across a crowded room. You whisper it to your assistant.
+- Your assistant keeps your private records (like transaction history and account balances) in a locked file cabinet that only they and you can open.
+- When you want to interact with a public service (a dApp), you give your instructions to your assistant. They prepare all the necessary paperwork (the ZK-proof) privately in their office before going out and executing the transaction on your behalf, revealing only the bare minimum required.
+
+## Core Responsibilities of the PXE
+
+1.  **Key Management:** The PXE securely stores and manages all of your cryptographic keys:
+    -   **Privacy Keys:** Used to encrypt and decrypt your private notes (your transaction data).
+    -   **Authentication Keys:** Used to sign and authorize transactions (like the private key for our Schnorr account).
+
+2.  **State Management (The Locked File Cabinet):** The PXE maintains a local, private database (like LMDB) of all your encrypted notes. It continuously scans the global Aztec network for new notes that belong to you, decrypts them with your privacy keys, and adds them to your private state. This is how your wallet "receives" funds.
+
+3.  **Private Execution & Proof Generation (The Assistant's Office):** This is the PXE's most important job. When you want to send a transaction (e.g., call the `cast_vote` function):
+    -   You tell your PXE your intent.
+    -   The PXE gathers all the necessary private inputs (the notes you'll spend, your keys).
+    -   It executes the private function logic **locally on your machine**.
+    -   As it executes, it generates a **Zero-Knowledge Proof (ZK-proof)** that proves you followed the contract's rules correctly, without revealing any of the private details (who you are, what you're spending, etc.).
+    -   This is also where **Oracle Calls** (like `get_auth_witness` or `request_nsk_app`) happen. The contract execution "pauses" and asks the PXE for a piece of secret information, which the PXE provides directly into the proof generation process.
+
+4.  **Transaction Broadcasting:** Once the ZK-proof is generated, the PXE bundles it with any required public data and sends the final, secure transaction to an Aztec Sequencer for inclusion on the network.
+
+## Why is the PXE so Important?
+
+Without the PXE, there is no privacy. All the magic of zero-knowledge—private state, secret function arguments, shielded balances—is only possible because there is a trusted, client-side environment to manage secrets and generate proofs. It moves the sensitive parts of computation off the public chain and into the user's direct control, which is the cornerstone of the Aztec privacy model. 

--- a/session_3/4-Full--Stack-Dapp-Tutorial/yarnrc.yml
+++ b/session_3/4-Full--Stack-Dapp-Tutorial/yarnrc.yml
@@ -1,0 +1,1 @@
+nodeLinker: node-modules 

--- a/session_3/4-Full-Stack-Dapp-Tutorial/README.md
+++ b/session_3/4-Full-Stack-Dapp-Tutorial/README.md
@@ -1,0 +1,150 @@
+# 4. Full-Stack Aztec dApp Tutorial
+
+Welcome to the capstone project for Session 3! In this tutorial, we will bring together everything we've learned to build, deploy, and interact with a full-stack Aztec dApp.
+
+**Goal:** Create a hybrid Token contract (with both private and public state), interact with it from a Node.js application using `aztec.js`, and write automated tests with Jest.
+
+This tutorial is divided into three main parts:
+1.  **Contract Deployment:** Writing and setting up the Noir smart contract.
+2.  **Contract Interaction:** Using `aztec.js` to call our contract's functions.
+3.  **Application Testing:** Ensuring our dApp works correctly with Jest.
+
+---
+
+## Part 1: Contract Deployment (Noir)
+
+### Step 1: Initialize the Noir Project
+
+First, create a directory for the Noir contract and initialize a new Aztec project.
+
+```bash
+# From the root of the full-stack-dapp-tutorial/ directory
+mkdir -p contracts/token
+cd contracts/token
+aztec-nargo new --contract .
+```
+*Note: Using `.` creates the project in the current directory.*
+
+### Step 2: Configure Dependencies (`Nargo.toml`)
+
+Open `Nargo.toml` and add the necessary dependencies for our advanced token contract.
+
+```toml
+[package]
+name = "token"
+authors = [""]
+compiler_version = ">=0.23.0"
+type = "contract"
+
+[dependencies]
+aztec = { git="https://github.com/AztecProtocol/aztec-packages/", tag="v0.87.4", directory="noir-projects/aztec-nr/aztec" }
+authwit = { git="https://github.com/AztecProtocol/aztec-packages/", tag="v0.87.4", directory="noir-projects/aztec-nr/authwit"}
+uint_note = { git="https://github.com/AztecProtocol/aztec-packages/", tag="v0.87.4", directory="noir-projects/aztec-nr/uint-note" }
+compressed_string = {git="https://github.com/AztecProtocol/aztec-packages/", tag="v0.87.4", directory="noir-projects/aztec-nr/compressed-string"}
+```
+
+### Step 3: Write the Contract Code
+
+Our `Token` contract will have several custom types for handling strings and balances. Create the following files and directories:
+
+-   `src/types/balance_set.nr`
+-   `src/types/name.nr`
+-   `src/types/symbol.nr`
+-   `src/main.nr`
+
+Populate these files with the complete source code provided in their respective directories within this tutorial. They define the logic for a hybrid token with private balances, public supply, minting controls, and transfer capabilities.
+
+### Step 4: Compile the Contract
+
+From within the `contracts/token` directory, compile your Noir code.
+
+```bash
+aztec-nargo compile
+```
+
+This creates the contract artifact at `target/token-Token.json`, which our TypeScript app will need.
+
+---
+
+## Part 2: Contract Interaction (TypeScript)
+
+### Step 1: Set Up the Node.js Project
+
+Navigate back to the root of the `full-stack-dapp-tutorial` directory.
+
+-   Create the `package.json`, `tsconfig.json`, and `.yarnrc.yml` files as provided in this tutorial.
+-   Install dependencies: `yarn install`
+
+### Step 2: Write the Deployment Script
+
+Before we can interact with our contract, we need to deploy it. Create a script for this at `src/deployment.mjs`.
+
+**`src/deployment.mjs`**
+```javascript
+import { createPXEClient, waitForPXE, Deployer, Fr } from '@aztec/aztec.js';
+import { getInitialTestAccountsWallets } from '@aztec/accounts/testing';
+import { TokenContract } from '@aztec/noir-contracts.js/Token';
+import { writeFileSync } from 'fs';
+
+const { PXE_URL = 'http://localhost:8080' } = process.env;
+
+async function main() {
+  const pxe = createPXEClient(PXE_URL);
+  await waitForPXE(pxe);
+  const [owner] = await getInitialTestAccountsWallets(pxe);
+  
+  console.log('Deploying Token contract...');
+  const contract = await TokenContract.deploy(owner, owner.getAddress(), 'TestToken', 'TST', 18).send().deployed();
+  
+  console.log(`Token contract deployed at ${contract.address.toString()}`);
+  
+  // Save the address for other scripts
+  writeFileSync('addresses.json', JSON.stringify({ token: contract.address.toString() }));
+}
+
+main().catch(e => {
+  console.error(e);
+  process.exit(1);
+});
+```
+
+Run the deployment script:
+```bash
+node src/deployment.mjs
+```
+This will deploy the contract and create an `addresses.json` file.
+
+### Step 3: Write the Interaction Script
+
+Now create the `src/index.mjs` and `src/contracts.mjs` files as provided in this tutorial. `index.mjs` contains the logic to connect to the PXE and call the various mint and transfer functions, demonstrating the dApp's capabilities.
+
+Run the interaction script:
+```bash
+node src/index.mjs
+```
+You will see the balances printed before and after each private mint, public mint, and private transfer, showing the hybrid state model in action.
+
+---
+
+## Part 3: Testing Your Application (Jest)
+
+### Step 1: Write the Test File
+
+Create the `src/index.test.mjs` file as provided in this tutorial. This Jest test will:
+1.  Run a `beforeAll` hook to deploy a fresh, isolated `TokenContract` instance for testing.
+2.  Mint an initial private balance to an `owner` account.
+3.  Run a test case (`it` block) that transfers tokens to a `recipient` and asserts that the recipient's balance correctly increases.
+
+### Step 2: Run the Tests
+
+Execute the tests using the command specified in `package.json`:
+
+```bash
+yarn test
+```
+
+You will see Jest's output confirming that the test setup completed and the transfer test passed successfully.
+
+## Conclusion
+
+Congratulations! You have successfully built a complete full-stack dApp on Aztec, from writing a complex hybrid-state Noir contract to interacting with it via TypeScript and verifying its functionality with automated tests. You now have a solid foundation to build the next generation of private, scalable applications. 

--- a/session_3/4-Full-Stack-Dapp-Tutorial/contracts/token/Nargo.toml
+++ b/session_3/4-Full-Stack-Dapp-Tutorial/contracts/token/Nargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "token"
+authors = [""]
+compiler_version = ">=0.23.0"
+type = "contract"
+
+[dependencies]
+aztec = { git="https://github.com/AztecProtocol/aztec-packages/", tag="v0.87.4", directory="noir-projects/aztec-nr/aztec" }
+authwit = { git="https://github.com/AztecProtocol/aztec-packages/", tag="v0.87.4", directory="noir-projects/aztec-nr/authwit"}
+uint_note = { git="https://github.com/AztecProtocol/aztec-packages/", tag="v0.87.4", directory="noir-projects/aztec-nr/uint-note" }
+compressed_string = {git="https://github.com/AztecProtocol/aztec-packages/", tag="v0.87.4", directory="noir-projects/aztec-nr/compressed-string"} 

--- a/session_3/4-Full-Stack-Dapp-Tutorial/contracts/token/src/main.nr
+++ b/session_3/4-Full-Stack-Dapp-Tutorial/contracts/token/src/main.nr
@@ -1,0 +1,163 @@
+use dep::aztec::{
+    context::{PrivateContext, PublicContext, Context},
+    log::emit_log,
+    state_vars::{map::Map, public_state::PublicState, immutable_state::ImmutableState},
+};
+
+use dep::aztec::constants::{MAX_PRIVATE_CALL_STACK_LENGTH_PER_TX, MAX_PUBLIC_CALL_STACK_LENGTH_PER_TX};
+
+use dep::authwit::{
+    auth_witness::get_auth_witness,
+    aztec_address::AztecAddress,
+    entrypoint::{fee::FeePayload, app::AppPayload,},
+    account::AccountActions,
+};
+
+use crate::types::{
+    balance_set::BalanceSet,
+    symbol::Symbol,
+    name::Name
+};
+
+#[contract]
+mod Token {
+    use super::*;
+
+    struct Storage {
+        balances: Map<AztecAddress, BalanceSet>,
+        total_supply: PublicState<Field>,
+        minters: Map<AztecAddress, PublicState<bool>>,
+        admin: ImmutableState<AztecAddress>,
+        name: ImmutableState<Name>,
+        symbol: ImmutableState<Symbol>,
+        decimals: ImmutableState<u8>,
+    }
+
+    #[event]
+    struct Transfer {
+        from: AztecAddress,
+        to: AztecAddress,
+        amount: u128,
+        from_balance: u128,
+        to_balance: u128,
+    }
+
+    #[event]
+    struct Mint {
+        to: AztecAddress,
+        amount: u128,
+        new_total_supply: Field,
+        minter: AztecAddress,
+    }
+
+    #[initializer]
+    fn constructor(
+        admin: AztecAddress,
+        name: str<30>,
+        symbol: str<5>,
+        decimals: u8
+    ) {
+        storage.admin.initialize(admin);
+        storage.minters.at(admin).set(true);
+        storage.name.initialize(Name::from_str(name));
+        storage.symbol.initialize(Symbol::from_str(symbol));
+        storage.decimals.initialize(decimals);
+    }
+
+    #[private]
+    fn mint_to_private(to: AztecAddress, amount: u128) {
+        let new_total_supply = storage.total_supply.read() + (amount as Field);
+        Token::at(context.this_address()).mint_public(to, amount, new_total_supply, context.msg_sender()).enqueue(&mut context);
+        storage.balances.at(to).add(amount);
+    }
+
+    #[private]
+    fn mint_to_private_from_public(from: AztecAddress, to: AztecAddress, amount: u128) {
+        let auth = get_auth_witness(&mut context, from);
+        assert(auth.is_valid_for(from), "Invalid signature");
+        let new_total_supply = storage.total_supply.read() + (amount as Field);
+        Token::at(context.this_address()).mint_public(to, amount, new_total_supply, from).enqueue(&mut context);
+        storage.balances.at(to).add(amount);
+    }
+
+    #[internal]
+    fn mint_public(to: AztecAddress, amount: u128, new_total_supply: Field, minter: AztecAddress) {
+        assert(storage.minters.at(minter).read(), "Caller is not a minter");
+        storage.total_supply.set(new_total_supply);
+        emit_event(Mint { to, amount, new_total_supply, minter });
+    }
+
+    #[public]
+    fn mint_to_public(to: AztecAddress, amount: u128) {
+        assert(storage.minters.at(context.msg_sender()).read(), "Caller is not a minter");
+        let new_total_supply = storage.total_supply.read() + (amount as Field);
+        storage.total_supply.set(new_total_supply);
+        storage.balances.at(to).add(amount);
+        emit_event(Mint { to, amount, new_total_supply, minter: context.msg_sender() });
+    }
+
+    #[private]
+    fn transfer(to: AztecAddress, amount: u128) {
+        let from = context.msg_sender();
+        let from_balance = storage.balances.at(from).remove(amount);
+        let to_balance = storage.balances.at(to).add(amount);
+        emit_event(Transfer { from, to, amount, from_balance, to_balance });
+    }
+
+    #[private]
+    fn approve(spender: AztecAddress, amount: u128) {
+        let owner = context.msg_sender();
+        storage.balances.at(owner).add_allowance(spender, amount);
+    }
+
+    #[private]
+    fn transfer_from(owner: AztecAddress, recipient: AztecAddress, amount: u128) {
+        let caller = context.msg_sender();
+        storage.balances.at(owner).remove_allowance(caller, amount);
+        storage.balances.at(recipient).add(amount);
+        emit_event(
+            Transfer { from: owner, to: recipient, amount, from_balance: 0, to_balance: 0 }
+        );
+    }
+
+    #[public]
+    fn set_minter(minter: AztecAddress, approve: bool) {
+        assert(storage.admin.read().eq(context.msg_sender()), "Caller is not the admin");
+        storage.minters.at(minter).set(approve);
+    }
+
+    #[utility]
+    unconstrained fn get_total_supply() -> Field {
+        storage.total_supply.read()
+    }
+
+    #[utility]
+    unconstrained fn balance_of_private(owner: AztecAddress) -> u128 {
+        storage.balances.at(owner).balance_of()
+    }
+
+    #[utility]
+    unconstrained fn balance_of_public(owner: AztecAddress) -> Field {
+        0
+    }
+
+    #[utility]
+    unconstrained fn get_name() -> str<30> {
+        storage.name.read().as_str()
+    }
+
+    #[utility]
+    unconstrained fn get_symbol() -> str<5> {
+        storage.symbol.read().as_str()
+    }
+
+    #[utility]
+    unconstrained fn get_decimals() -> u8 {
+        storage.decimals.read()
+    }
+
+    #[utility]
+    unconstrained fn get_admin() -> AztecAddress {
+        storage.admin.read()
+    }
+} 

--- a/session_3/4-Full-Stack-Dapp-Tutorial/contracts/token/src/types/balance_set.nr
+++ b/session_3/4-Full-Stack-Dapp-Tutorial/contracts/token/src/types/balance_set.nr
@@ -1,0 +1,41 @@
+use dep::uint_note::balance_utils::BalanceUtils;
+use dep::aztec::aztec_address::AztecAddress;
+
+// The BalanceSet is a wrapper around the BalanceUtils library
+// It is used to manage the private balance of a user
+// and their allowances
+struct BalanceSet {
+    balance_utils: BalanceUtils<128>,
+}
+
+impl BalanceSet {
+    // Get a BalanceSet for a given user
+    pub fn at(owner: AztecAddress) -> Self {
+        BalanceSet { balance_utils: BalanceUtils::new(owner, 0) }
+    }
+
+    // Add an amount to the user's balance
+    pub fn add(self, amount: u128) -> u128 {
+        self.balance_utils.add(amount)
+    }
+
+    // Remove an amount from the user's balance
+    pub fn remove(self, amount: u128) -> u128 {
+        self.balance_utils.remove(amount)
+    }
+
+    // Get the user's balance
+    pub fn balance_of(self) -> u128 {
+        self.balance_utils.get_balance()
+    }
+
+    // Add an allowance for a spender
+    pub fn add_allowance(self, spender: AztecAddress, amount: u128) {
+        self.balance_utils.add_allowance(spender, amount)
+    }
+
+    // Remove an allowance for a spender
+    pub fn remove_allowance(self, spender: AztecAddress, amount: u128) {
+        self.balance_utils.remove_allowance(spender, amount)
+    }
+} 

--- a/session_3/4-Full-Stack-Dapp-Tutorial/contracts/token/src/types/name.nr
+++ b/session_3/4-Full-Stack-Dapp-Tutorial/contracts/token/src/types/name.nr
@@ -1,0 +1,20 @@
+use dep::compressed_string::CompressedString;
+
+// The Name is a wrapper around the CompressedString library
+// It is used to store the name of the token
+// in a compressed format
+struct Name {
+    name: CompressedString<30>,
+}
+
+impl Name {
+    // Get a Name from a string
+    pub fn from_str(name: str<30>) -> Self {
+        Name { name: CompressedString::new(name) }
+    }
+
+    // Get the name as a string
+    pub fn as_str(self) -> str<30> {
+        self.name.as_str()
+    }
+} 

--- a/session_3/4-Full-Stack-Dapp-Tutorial/contracts/token/src/types/symbol.nr
+++ b/session_3/4-Full-Stack-Dapp-Tutorial/contracts/token/src/types/symbol.nr
@@ -1,0 +1,20 @@
+use dep::compressed_string::CompressedString;
+
+// The Symbol is a wrapper around the CompressedString library
+// It is used to store the symbol of the token
+// in a compressed format
+struct Symbol {
+    symbol: CompressedString<5>,
+}
+
+impl Symbol {
+    // Get a Symbol from a string
+    pub fn from_str(symbol: str<5>) -> Self {
+        Symbol { symbol: CompressedString::new(symbol) }
+    }
+
+    // Get the symbol as a string
+    pub fn as_str(self) -> str<5> {
+        self.symbol.as_str()
+    }
+} 

--- a/session_3/4-Full-Stack-Dapp-Tutorial/package.json
+++ b/session_3/4-Full-Stack-Dapp-Tutorial/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "token",
+  "version": "1.0.0",
+  "type": "module",
+  "scripts": {
+    "build": "yarn clean && tsc -b",
+    "build:dev": "tsc -b --watch",
+    "clean": "rm -rf ./dest tsconfig.tsbuildinfo",
+    "start": "yarn build && node ./dest/index.js",
+    "test": "yarn node --experimental-vm-modules $(yarn bin jest) --testRegex '.*\\.test\\.mjs$'"
+  },
+  "dependencies": {
+    "@aztec/aztec.js": "0.87.4",
+    "@aztec/accounts": "0.87.4",
+    "@aztec/noir-contracts.js": "0.87.4",
+    "typescript": "^5.2.2",
+    "@types/node": "^20.8.2"
+  },
+  "devDependencies": {
+    "jest": "^29.7.0",
+    "ts-node": "^10.9.1"
+  }
+} 

--- a/session_3/4-Full-Stack-Dapp-Tutorial/src/contracts.mjs
+++ b/session_3/4-Full-Stack-Dapp-Tutorial/src/contracts.mjs
@@ -1,0 +1,10 @@
+import { AztecAddress, Contract, loadContractArtifact } from "@aztec/aztec.js";
+import TokenContractJson from "../contracts/token/target/token-Token.json" with { type: "json" };
+import { readFileSync } from "fs";
+
+const TokenContractArtifact = loadContractArtifact(TokenContractJson);
+
+export async function getToken(wallet) {
+  const addresses = JSON.parse(readFileSync('addresses.json', 'utf8'));
+  return Contract.at(AztecAddress.fromString(addresses.token), TokenContractArtifact, wallet);
+} 

--- a/session_3/4-Full-Stack-Dapp-Tutorial/src/index.mjs
+++ b/session_3/4-Full-Stack-Dapp-Tutorial/src/index.mjs
@@ -1,0 +1,84 @@
+import { getInitialTestAccountsWallets } from '@aztec/accounts/testing';
+import { createPXEClient, waitForPXE } from '@aztec/aztec.js';
+import { getToken } from './contracts.mjs';
+
+const { PXE_URL = 'http://localhost:8080' } = process.env;
+
+async function showPrivateBalances(pxe) {
+  const [owner] = await getInitialTestAccountsWallets(pxe);
+  const token = await getToken(owner);
+  const accounts = await pxe.getRegisteredAccounts();
+  for (const account of accounts) {
+    const balance = await token.methods.balance_of_private(account.address).simulate();
+    console.log(`Private balance of ${account.address}: ${balance}`);
+  }
+}
+
+async function showPublicBalances(pxe) {
+  const [owner] = await getInitialTestAccountsWallets(pxe);
+  const token = await getToken(owner);
+  const accounts = await pxe.getRegisteredAccounts();
+  for (const account of accounts) {
+    const balance = await token.methods.balance_of_public(account.address).simulate();
+    console.log(`Public Balance of ${account.address}: ${balance}`);
+  }
+}
+
+async function mintPrivateFunds(pxe) {
+  const [ownerWallet] = await getInitialTestAccountsWallets(pxe);
+  const token = await getToken(ownerWallet);
+  console.log('\nBalances BEFORE private minting:');
+  await showPrivateBalances(pxe);
+  const mintAmount = 20n;
+  const from = ownerWallet.getAddress();
+  console.log(`\nMinting ${mintAmount} private tokens to ${ownerWallet.getAddress().toString()}...`);
+  await token.methods.mint_to_private(from, ownerWallet.getAddress(), mintAmount).send().wait();
+  console.log('\nBalances AFTER private minting:');
+  await showPrivateBalances(pxe);
+}
+
+async function mintPublicFunds(pxe) {
+  const [owner] = await getInitialTestAccountsWallets(pxe);
+  const token = await getToken(owner);
+  console.log('\nPublic Balances BEFORE public mint:');
+  await showPublicBalances(pxe);
+  console.log(`\nSending public mint transaction, awaiting transaction to be mined`);
+  const receipt = await token.methods.mint_to_public(owner.getAddress(), 100n).send().wait();
+  console.log(`Transaction ${receipt.txHash} has been mined on block ${receipt.blockNumber}`);
+  console.log('\nPublic Balances AFTER public mint:');
+  await showPublicBalances(pxe);
+  const blockNumber = await pxe.getBlockNumber();
+  const logs = (await pxe.getPublicLogs({ fromBlock: blockNumber - 1 })).logs;
+  const textLogs = logs.map(extendedLog => extendedLog.toHumanReadable().slice(0, 200));
+  for (const log of textLogs) console.log(`Log emitted: ${log}`);
+}
+
+async function transferPrivateFunds(pxe) {
+  const [owner, recipient] = await getInitialTestAccountsWallets(pxe);
+  const token = await getToken(owner);
+  console.log('\nBalances BEFORE transfer:');
+  await showPrivateBalances(pxe);
+  const transferAmount = 1n;
+  console.log(`\nTransferring ${transferAmount} private tokens from ${owner.getAddress().toString()} to ${recipient.getAddress().toString()}...`);
+  const receipt = await token.methods.transfer(recipient.getAddress(), transferAmount).send().wait();
+  console.log(`Transaction ${receipt.txHash} has been mined on block ${receipt.blockNumber}`);
+  console.log('\nBalances AFTER transfer:');
+  await showPrivateBalances(pxe);
+}
+
+async function main() {
+  const pxe = createPXEClient(PXE_URL);
+  await waitForPXE(pxe);
+
+  const nodeInfo = await pxe.getNodeInfo();
+  console.log('Aztec Sandbox Info:', nodeInfo);
+
+  await mintPrivateFunds(pxe);
+  await mintPublicFunds(pxe);
+  await transferPrivateFunds(pxe);
+}
+
+main().catch(error => {
+  console.error(error);
+  process.exit(1);
+}); 

--- a/session_3/4-Full-Stack-Dapp-Tutorial/src/index.test.mjs
+++ b/session_3/4-Full-Stack-Dapp-Tutorial/src/index.test.mjs
@@ -1,0 +1,35 @@
+import { getDeployedTestAccountsWallets } from '@aztec/accounts/testing';
+import { createPXEClient, waitForPXE } from '@aztec/aztec.js';
+import { TokenContract } from '@aztec/noir-contracts.js/Token';
+
+const {
+  PXE_URL = "http://localhost:8080",
+} = process.env;
+
+describe("token contract", () => {
+  let owner, recipient, token;
+
+  beforeAll(async () => {
+    const pxe = createPXEClient(PXE_URL);
+    await waitForPXE(pxe);
+
+    [owner, recipient] = await getDeployedTestAccountsWallets(pxe);
+
+    const initialBalance = 69n;
+    token = await TokenContract.deploy(owner, owner.getAddress(), 'TestToken', 'TST', 18).send().deployed();
+
+    await token.methods.mint_to_private(owner.getAddress(), owner.getAddress(), initialBalance).send().wait();
+
+    console.log(`Test Setup: Token deployed at ${token.address.toString()}`);
+    console.log(`Test Setup: Owner balance initially ${initialBalance}`);
+  }, 120_000);
+
+  it('increases recipient funds on transfer', async () => {
+    expect(await token.withWallet(recipient).methods.balance_of_private(recipient.getAddress()).simulate()).toEqual(0n);
+
+    console.log(`Test: Transferring 20 tokens from ${owner.getAddress().toString()} to ${recipient.getAddress().toString()}`);
+    await token.methods.transfer(recipient.getAddress(), 20n).send().wait();
+
+    expect(await token.withWallet(recipient).methods.balance_of_private(recipient.getAddress()).simulate()).toEqual(20n);
+  }, 30_000);
+}); 

--- a/session_3/4-Full-Stack-Dapp-Tutorial/tsconfig.json
+++ b/session_3/4-Full-Stack-Dapp-Tutorial/tsconfig.json
@@ -1,0 +1,23 @@
+{
+  "compilerOptions": {
+    "outDir": "dest",
+    "rootDir": "src",
+    "target": "es2020",
+    "lib": ["dom", "esnext", "es2017.object"],
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "strict": true,
+    "declaration": true,
+    "allowSyntheticDefaultImports": true,
+    "esModuleInterop": true,
+    "downlevelIteration": true,
+    "inlineSourceMap": true,
+    "declarationMap": true,
+    "importHelpers": true,
+    "resolveJsonModule": true,
+    "composite": true,
+    "skipLibCheck": true
+  },
+  "references": [],
+  "include": ["src", "src/*.json"]
+} 


### PR DESCRIPTION
This pull request introduces the complete educational materials for **Session 3:**. This session provides a deep, hands-on dive into advanced Aztec concepts, including private voting, account abstraction, and building a full-stack decentralized application.

This PR also addresses a direct community question by adding a detailed explanation of Aztec's event/logging system to Session 2, ensuring our educational content evolves with our builders' needs.

---

#### **Detailed Breakdown of New Content**

This pull request is composed of two main contributions: the full content for Session 3 and a key addition to Session 2.

##### **1. New Directory: `session_3/`**

This new session is structured into four distinct modules, each providing both high-level guidance and granular, line-by-line explanations to cater to different learning styles.

*   **Private Voting Contract (`/1-Private-Voting-Contract`)**
    *   A practical tutorial for writing a private on-chain voting contract in Noir.
    *   Includes a straightforward `README.md` for quick setup and an `EXPLAINED.md` for developers who want a deeper understanding of the code's logic.

*   **Account Abstraction Deep Dive (`/2-Account-Abstraction`)**
    *   Explores one of Aztec's most powerful features through a two-part guide:
        1.  **Noir Contract:** Details the implementation of a custom `SchnorrHardcodedAccount` contract.
        2.  **TypeScript Interaction:** Provides the client-side code to connect to and interact with the custom account contract using Aztec.js.

*   **Key Concepts Explained (`/3-Key-Concepts-Deep-Dive`)**
    *   A collection of DevRel-style markdown files that break down complex Aztec primitives using simple, effective analogies:
        *   `PXE.md`: The Private Execution Environment.
        *   `Nullifiers.md`: The mechanism for preventing double-spending.
        *   `Account_Abstraction_vs_EVM.md`: A clear comparison for Ethereum developers.
        *   `Authwit.md`: An explanation of Authentication Witnesses.
        *   `Oracles.md`: How to bring external data into private execution contexts.

*   **Full-Stack dApp Tutorial (`/4-Full-Stack-Dapp-Tutorial`)**
    *   An end-to-end guide for building a complete dApp on the Aztec Sandbox.
    *   **Contracts:** A private `Token` contract with minting and transfer functionality.
    *   **Application Logic:** TypeScript scripts to compile, deploy, and interact with the contract.
    *   **Testing:** A Jest test file (`index.test.mjs`) demonstrating how to write automated tests for an Aztec dApp.
    *   Includes all necessary configuration files (`package.json`, `tsconfig.json`, etc.).

##### **2. Enhancement: `session_2/` - Answering Community Questions**

*   **New File: `04_deep_dive_aztec_events.md`**
    *   In response to a builder's question about an equivalent to Solidity's `events`, this document was created and added to Session 2, where the question first arose.
    *   It provides a comprehensive explanation of Aztec's powerful logging system, covering both **public (unencrypted)** and **private (encrypted)** logs.
    *   To provide authoritative sources, it **cites and links directly to the official Aztec documentation**.
    *   It uses practical code examples from the new Session 3 content to demonstrate the end-to-end flow of defining, emitting, and querying logs.
gAztec